### PR TITLE
FullForm & OutputForm should not use MathML

### DIFF
--- a/mathics_django/web/views.py
+++ b/mathics_django/web/views.py
@@ -155,14 +155,7 @@ def query(request):
                 results.append(Result(evaluation.out, None, None))  # syntax errors
                 evaluation.out = []
                 continue
-            # START HERE.
-            # Handle unformatted.
             result = evaluation.evaluate(expr, timeout=settings.TIMEOUT)
-            if str(result.last_eval) == "-Graph-":
-                from mathics_django.web.format import format_graph
-                svg_path = format_graph(result.last_eval.G)
-                result.result="""<math><mi href="file://%s">Graph file://%s</mi></math>""" % (svg_path, svg_path)
-
             if result.result is not None:
                 result.result = replace_wl_to_unicode(result.result)
             results.append(result)  # syntax errors


### PR DESCRIPTION
@mmatera @GarkGarcia 

This change is very important. Please look over carefully. 

(* Begin Rant *)
There has been some fundamental wrongness of thinking that I am trying to undo here. 
Decisions about how to format output is not a one-size-fits-all kind of thing and can be declared in advance of evaluation as a single value (like "xml" for Django). 

Instead, the format of result of an evaluation is based on: 
* the kind of result produced,
* the capabilities of the front end, and 
* any format desire specified, 

Specifically in the Django interface, not everything should be formatted as MathML. And if IWolfram does that too, that is also probably wrong. 

Also, I don't get why we treat XML as synomymous for MathML. They are not the same. Or that graphics for TeX is asymptote.

Formatting for particular backends like SVG, MathML and aysmptote need to come out of the core. 

That should be addressed down the line. 

(* End Rant *)

This PR starts to put final formatting decisions more in control of mathics-django.

To do this we set the output format to be "unformatted". This prevents Mathics Core from trying to make any decision and allows mathics-django's web/format.py to make decisions about the final formatting.

In particular, we want OutpuForm and FullForm *not* to produce MathML.
Instead it should produce plain-ol' text which you can cut and paste.

Worse, OutputForm[Rectangle[]] was producing a graphic when it shouldn't have been.

There still seems to be a bug with FullForm not expanding graphics primitives, but that can come later.

I should also mention something about matplotib graphics that has been working crudely, (but still working) in the Django interface. Check out the pymathics-graph project and in the README.rst there are some simple commands that you can try in either mathicsscript of mathics-django. 

In ths PR, that has gotten a little bit better because we render matplotlib filenames better now  since
that is no longer MathML, but cut and pateable text. It is still not clickable: a html link would be nice, but that exceeds my knowledge of how to get done in this code with django. 