### PR TITLE
Fixing to match the current Mathics version

### DIFF
--- a/mathics_django/doc/doc.py
+++ b/mathics_django/doc/doc.py
@@ -16,7 +16,6 @@ from mathics.builtin import get_module_doc
 from mathics.core.evaluation import Message, Print
 from mathics_django.doc.utils import slugify
 
-
 CHAPTER_RE = re.compile('(?s)<chapter title="(.*?)">(.*?)</chapter>')
 SECTION_RE = re.compile('(?s)(.*?)<section title="(.*?)">(.*?)</section>')
 SUBSECTION_RE = re.compile('(?s)<subsection title="(.*?)">')
@@ -1126,6 +1125,10 @@ class DocTests(object):
     def test_indices(self):
         return [test.index for test in self.tests]
 
+# This string is used so we can indicate a trailing blank at the end of a line by
+# adding this string to the end of the line which gets stripped off.
+# Some editors and formatters like to strip off trailing blanks at the ends of lines.
+END_LINE_SENTINAL = "#<--#"
 
 class DocTest(object):
     """
@@ -1143,6 +1146,23 @@ class DocTest(object):
       `|`  Prints output.
     """
     def __init__(self, index, testcase):
+        def strip_sentinal(line):
+            """Remove END_LINE_SENTINAL from the end of a line if it appears.
+
+            Some editors like to strip blanks at the end of a line.
+            Since the line ends in END_LINE_SENTINAL which isn't blank,
+            any blanks that appear before will be preserved.
+
+            Some tests require some lines to be blank or entry because
+            Mathics output can be that way
+            """
+            if line.endswith(END_LINE_SENTINAL):
+                line = line[:-len(END_LINE_SENTINAL)]
+
+            # Also remove any remaining trailing blanks since that
+            # seems *also* what we want to do.
+            return line.strip()
+
         self.index = index
         self.result = None
         self.outs = []
@@ -1159,16 +1179,12 @@ class DocTest(object):
         else:
             self.ignore = False
 
-        self.test = testcase[1].strip()
-
-        # This allows a trailing blank at the end of the line for those ofus use use editors that like
-        # to strip trailing blanks at the ends of lines.
-        self.test = self.test.rstrip("#<--#")
+        self.test = strip_sentinal(testcase[1])
 
         self.key = None
         outs = testcase[2].splitlines()
         for line in outs:
-            line = line.strip()
+            line = strip_sentinal(line)
             if line:
                 if line.startswith('.'):
                     text = line[1:]
@@ -1178,7 +1194,7 @@ class DocTest(object):
                     if self.result is not None:
                         self.result += text
                     elif self.outs:
-                        self.outs[-1] += text
+                        self.outs[-1].text += text
                     continue
 
                 match = TESTCASE_OUT_RE.match(line)
@@ -1186,11 +1202,11 @@ class DocTest(object):
                 text = text.strip()
                 if symbol == '=':
                     self.result = text
-                elif text:
-                    if symbol == ':':
-                        out = Message('', '', text)
-                    elif symbol == '|':
-                        out = Print(text)
+                elif symbol == ':':
+                    out = Message('', '', text)
+                    self.outs.append(out)
+                elif symbol == '|':
+                    out = Print(text)
                     self.outs.append(out)
 
     def __str__(self):

--- a/mathics_django/test.py
+++ b/mathics_django/test.py
@@ -12,7 +12,7 @@ import mathics
 
 from mathics.core.definitions import Definitions
 from mathics.core.evaluation import Evaluation, Output
-from mathics.core.parser import SingleLineFeeder
+from mathics.core.parser import MathicsSingleLineFeeder
 from mathics.builtin import builtins
 
 from mathics import version_string

--- a/mathics_django/web/views.py
+++ b/mathics_django/web/views.py
@@ -160,7 +160,6 @@ def query(request):
         query_log.result = str(result)  # evaluation.results
         query_log.error = False
         query_log.save()
-    print(result)
     return JsonResponse(result)
 
 

--- a/mathics_django/web/views.py
+++ b/mathics_django/web/views.py
@@ -103,7 +103,7 @@ def error_500_view(request):
 
 def query(request):
     global definitions
-    from mathics.core.parser import MultiLineFeeder
+    from mathics.core.parser import MathicsMultiLineFeeder
 
     input = request.POST.get("query", "")
     if settings.DEBUG and not input:
@@ -123,7 +123,7 @@ def query(request):
         query_log.save()
 
     evaluation = get_session_evaluation(request.session)
-    feeder = MultiLineFeeder(input, "<notebook>")
+    feeder = MathicsMultiLineFeeder(input, "<notebook>")
     results = []
     try:
         while not feeder.empty():
@@ -160,7 +160,7 @@ def query(request):
         query_log.result = str(result)  # evaluation.results
         query_log.error = False
         query_log.save()
-
+    print(result)
     return JsonResponse(result)
 
 


### PR DESCRIPTION
This PR fix errors comming from the recent change in the Mathics core interface: 
* LineFeeder and MultilineFeeder are now called MathicsLineFeeder and MathicsMultilineFeeder
* Some changes in the way that docstrings are reader requires an update in mathics_djando doc module.