### PR TITLE
About

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ CHANGES
 * Upgrade three.js to r52. See PR #36.
 * Allow Django's database (default ``mathics.sqlite``) to be settable from environment variables ``MATHICS_DJANGO_DB`` and ``MATHICS_DJANGO_DB_PATH``.
 * Update gallery examples with more graphics
+* Add an "about" page to show version information and for installed software three.js and MathJax.
 
 2.1.0
 -----

--- a/mathics_django/web/media/css/styles.css
+++ b/mathics_django/web/media/css/styles.css
@@ -270,6 +270,23 @@ a.pdf {
   display: inline-block;
 }
 
+#about {
+  position:relative;
+  margin: 14px;
+  top: 54px;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: white;
+  overflow: auto;
+  padding-top: 14px;
+  z-index: 0;
+  padding: 14px 1.5em 28px 1.5em;
+  display: flex;
+  flex-direction: row;
+
+}
+
 #document,
 #code {
   position: absolute;

--- a/mathics_django/web/templates/about.html
+++ b/mathics_django/web/templates/about.html
@@ -1,0 +1,52 @@
+{% extends "base_html.html" %}
+{% load static %}
+
+{% block title %}Mathics Installation Information{% endblock %}
+
+{% block html_head %}
+{% endblock %}
+
+{% block html_body %}
+
+<header>
+<div id="headerleft">
+  <a href="https://mathics.org">
+    <img id="logo" class="load" src="{% static 'img/logo-heptatom.svg' %}" height="32" alt="Logo" />
+    <img id="logotext" class="load" src="{% static 'img/logo-text.svg' %}" height="26" alt="Mathics" />
+  </a>
+
+  <!-- worksheet controls are not wanted here ->
+  <!--
+  <div class="menu">
+    <a href="javascript:showOpen()" title="Open Worksheet"><i class="fa fa-file-text"></i></a>
+    <a href="javascript:showSave()" title="Save Worksheet"><i class="fa fa-download"></i></a>
+    <a href="javascript:createLink()" title="Generate Worksheet Input Hash"><i class="fa fa-share-alt"></i></a>
+  </div>
+  -->
+</div>
+</header>
+
+{% block main %}
+
+<div id="about">
+
+  <h1> Version information </h1>
+
+  <p>
+    <ul>
+      <li>Django: {{django_version}}</li>
+      <li>three.js: {{three_js_version}}</li>
+      <li>MathJax: {{MathJax_version}}</li>
+      <li>Mathics: {{mathics_version}}</li>
+      <li>Mathics Django: {{mathics_django_version}}</li>
+      <li>mpmath: {{mpmath_version}}</li>
+      <li>Numpy: {{numpy_version}}</li>
+      <li>Python: {{python_version}}</li>
+      <li>Sympy: {{sympy_version}}</li>
+    </ul>
+  </p>
+</div>
+
+
+{% endblock main %}
+{% endblock html_body %}

--- a/mathics_django/web/urls.py
+++ b/mathics_django/web/urls.py
@@ -4,24 +4,26 @@
 
 from django.conf.urls import url
 from mathics_django.web.views import (
-    query,
-    main_view,
+    about_view,
+    delete,
+    doc,
+    doc_chapter,
+    doc_part,
+    doc_search,
+    doc_section,
+    get_worksheets,
     login,
     logout,
-    save,
+    main_view,
     open,
-    delete,
-    get_worksheets,
-    doc_search,
-    doc_part,
-    doc_chapter,
-    doc_section,
-    doc,
+    query,
+    save,
 )
 
 urlpatterns = [
     # 'mathics.web.views',
     url("^$", main_view),
+    url("^about(?:\.htm(?:l)?)?$", about_view),
     url("^ajax/query/$", query),
     url("^ajax/login/$", login),
     url("^ajax/logout/$", logout),


### PR DESCRIPTION
Add rudimentary "about" url `http://localhost:8000/about`, htttp://localhost/about.html`, htttp://localhost/about.htm` 

which prints what version of Django, MathJax, three.js and Mathics-version info that is getting used.

Unless there is interest or objections in using, I'll merge over the weekend.