### PR TITLE
Don't use MathJax for string output

### DIFF
--- a/mathics_django/web/format.py
+++ b/mathics_django/web/format.py
@@ -60,8 +60,11 @@ def format_output(obj, expr, format=None):
         # This part is custom to mathics-django:
         if str(expr) == "-Graph-" and hasattr(expr, "G"):
             return format_graph(expr.G)
-        elif str(expr.get_head()) == 'System`CompiledFunction':
+        head = str(expr.get_head())
+        if head == 'System`CompiledFunction':
             result = expr.format(obj, "System`OutputForm")
+        elif head == 'System`String':
+            result = expr.format(obj, "System`InputForm")
         else:
             result = Expression("StandardForm", expr).format(obj, "System`MathMLForm")
     else:


### PR DESCRIPTION
This is minimal code. Down the line I'd like to put this under a setting, specific to Django. 

But doing this properly means redoing how settings work in Mathics. The Django-specific setting there in `Settings.m` should be moved here. 

But doing this properly means pulling out the autoload part of of Definitions and putting that into its own function.  Sigh. 