### PR TITLE
Add color to axes numbers in 3D plot

### DIFF
--- a/mathics_django/web/media/js/graphics3d.js
+++ b/mathics_django/web/media/js/graphics3d.js
@@ -525,10 +525,19 @@ function drawGraphics3D(container, data) {
   var ticknums = new Array(3);
   for (var i = 0; i < 3; i++) {
     if (hasaxes[i]) {
+      var color;
+      if (i == 0) {
+        color = 'red';
+      } else if (i == 1) {
+        color = 'green';
+      } else {
+        color = 'blue';
+      }
+
       ticknums[i] = new Array(data.axes.ticks[i][0].length);
       for (var j = 0; j < ticknums[i].length; j++) {
         ticknums[i][j] = document.createElement('div');
-        ticknums[i][j].innerHTML = data.axes.ticks[i][2][j];
+        ticknums[i][j].innerHTML = data.axes.ticks[i][2][j].replace('0.', '.');
 
         // Handle Minus signs
         if (data.axes.ticks[i][0][j] >= 0) {
@@ -539,6 +548,7 @@ function drawGraphics3D(container, data) {
 
         ticknums[i][j].style.position = "absolute";
         ticknums[i][j].style.fontSize = "0.8em";
+        ticknums[i][j].style.color = color;
         container.appendChild(ticknums[i][j]);
       }
     }

--- a/mathics_django/web/media/js/graphics3d.js
+++ b/mathics_django/web/media/js/graphics3d.js
@@ -525,6 +525,7 @@ function drawGraphics3D(container, data) {
   var ticknums = new Array(3);
   for (var i = 0; i < 3; i++) {
     if (hasaxes[i]) {
+      // TODO: implement TickStyle for 3D graphics (see page 132 of https://mathics.org/docs/mathics-latest.pdf)
       var color;
       if (i == 0) {
         color = 'red';


### PR DESCRIPTION
I added colors to the axes numbers in 3D plot with the same color scheme than Sketchup (x: red, y: green, z: blue) and also replaced `0.` by `.` in the  axes numbers of 3D plot for better visualization.

![example of 3D graphic after my changes](https://user-images.githubusercontent.com/62714153/118518276-56494680-b70e-11eb-81b4-7394886b4a13.png)