### PR TITLE
Remove link underline between logo and Mathics

### DIFF
--- a/mathics_django/web/templates/about.html
+++ b/mathics_django/web/templates/about.html
@@ -8,7 +8,7 @@
 
 {% block html_body %}
 	<header>
-		<a href="https://mathics.org">
+		<a href="https://mathics.org" style="text-decoration: none">
 			<img id="logo" class="load" src="{% static 'img/logo-heptatom.svg' %}" height="32" alt="Logo" />
 			<img id="logotext" class="load" src="{% static 'img/logo-text.svg' %}" height="26" alt="Mathics" />
 		</a>

--- a/mathics_django/web/templates/base.html
+++ b/mathics_django/web/templates/base.html
@@ -11,7 +11,7 @@
 {% block html_body %}
 	<header>
 		<div id="headerleft">
-			<a href="https://mathics.org">
+			<a href="https://mathics.org" style="text-decoration: none">
 				<img id="logo" class="load" src="{% static 'img/logo-heptatom.svg' %}" height="32" alt="Logo" />
 				<img id="logotext" class="load" src="{% static 'img/logo-text.svg' %}" height="26" alt="Mathics" />
 			</a>


### PR DESCRIPTION
Having the log and Mathics text share an <a> tag with a space in between
causes there to be a link underline in between them.
I split these into two <a> tags.

Perhaps there is a better way?