### PR TITLE
Avoid MathML for Symbols and Integers

### DIFF
--- a/mathics_django/web/format.py
+++ b/mathics_django/web/format.py
@@ -105,6 +105,10 @@ def format_output(obj, expr, format=None):
             form_expr = Expression("StandardForm", expr)
             result = form_expr.format(obj, "System`StandardForm")
             return eval_boxes(result, result.boxes_to_svg, obj)
+        elif head in ("System`Symbol", "System`Integer"):
+            # What obviously doesn't need MathML? Note: System`Real is kept in MathML
+            # because we might have exponents, e.g. 3 * 10^8.
+            result = Expression("StandardForm", expr).format(obj, "System`OutputForm")
         else:
             result = Expression("StandardForm", expr).format(obj, "System`MathMLForm")
     else:


### PR DESCRIPTION
For your consideration. Reducing the use of MathML where it isn't needed reduces the need for it to want to reformat it on loading. 

The output changes slightly, and there may be additional styling, or not. 

I am curious to know what you think and what your opinion is.

(Also, down the line we need to come up with a better story and design for Format. Or just hide a lot of the ugliness into its own routine somewhere). 