### PR TITLE
Misc tweaks...

### DIFF
--- a/.github/workflows/osx.yaml
+++ b/.github/workflows/osx.yaml
@@ -25,8 +25,8 @@ jobs:
         python -m pip install --upgrade pip
         LLVM_CONFIG=/usr/local/Cellar/llvm@11/11.1.0/bin/llvm-config pip install llvmlite
         # Can comment out when next Mathics is released
-        python -m pip install -e git://github.com/mathics/Mathics#egg=Mathics3
-        pip install -e .
+        python -m pip install -e git://github.com/mathics/Mathics#egg=Mathics3[full]
+        pip install -e .[full]
     - name: Install Mathics Django
       run: |
         make develop

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -23,8 +23,8 @@ jobs:
         sudo apt-get update -qq && sudo apt-get install -qq liblapack-dev llvm-dev
         python -m pip install --upgrade pip
         # Can comment out when next Mathics is released
-        python -m pip install -e git://github.com/mathics/Mathics#egg=Mathics3
-        pip install -e .
+        python -m pip install -e git://github.com/mathics/Mathics#egg=Mathics3[full]
+        pip install -e .[full]
     - name: Install Mathics Django
       run: |
         make develop

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,8 +26,8 @@ jobs:
         choco install llvm
         set LLVM_DIR="C:\Program Files\LLVM"
         # Can comment out when next Mathics is released
-        python -m pip install -e git://github.com/mathics/Mathics#egg=Mathics3
-        pip install -e .
+        python -m pip install -e git://github.com/mathics/Mathics#egg=Mathics3[full]
+        pip install -e .[full]
     - name: Install Mathics Django
       run: |
         make develop

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-*~
 *.c
 *.cpp
 *.egg
@@ -6,6 +5,7 @@
 *.nix
 *.py[cod]
 *.so
+*~
 .coverage
 .idea/
 .mypy_cache
@@ -16,6 +16,8 @@
 /.cache
 /.python-version
 /Mathics_Django.egg-info
+/node_modules
+/package-lock.json
 ChangeLog
 Documents/
 Homepage/
@@ -25,11 +27,11 @@ _Copies_/
 _Database_/
 build/
 dist/
+env/
 mathics_django/Makefile
 mathics_django/web/db/mathics.sqlite
 mathics_django/web/media/doc/classes.pdf
 mathics_django/web/media/doc/classes.png
 mathics_django/web/media/pdf/
 tmp
-env/
 venv/

--- a/mathics_django/doc/django_doc.py
+++ b/mathics_django/doc/django_doc.py
@@ -42,7 +42,7 @@ try:
         xml_data = pickle.load(xml_data_file)
 except IOError:
     print(f"Trouble reading Doc XML file {DOC_XML_DATA_PATH}")
-    xml_data = {}
+    doc_data = {}
 
 
 def get_doc_name_from_module(module):
@@ -190,7 +190,7 @@ class MathicsMainDocumentation(Documentation):
         self.parts = []
         self.parts_by_slug = {}
         self.pymathics_doc_loaded = False
-        self.xml_data_file = DOC_XML_DATA_PATH
+        self.doc_data_file = DOC_XML_DATA_PATH
         self.doc_dir = settings.DOC_DIR
         files = listdir(self.doc_dir)
         files.sort()
@@ -442,7 +442,7 @@ class PyMathicsDocumentation(Documentation):
         self.parts = []
         self.parts_by_slug = {}
         self.doc_dir = None
-        self.xml_data_file = None
+        self.doc_data_file = None
         self.symbols = {}
         if module is None:
             return
@@ -475,7 +475,7 @@ class PyMathicsDocumentation(Documentation):
 
         # Paths
         self.doc_dir = self.pymathicsmodule.__path__[0] + "/doc/"
-        self.xml_data_file = self.doc_dir + "xml/data"
+        self.doc_data_file = self.doc_dir + "xml/data"
 
         # Load the dictionary of mathics symbols defined in the module
         self.symbols = {}
@@ -503,7 +503,7 @@ class PyMathicsDocumentation(Documentation):
             files.sort()
         except FileNotFoundError:
             self.doc_dir = ""
-            self.xml_data_file = ""
+            self.doc_data_file = ""
             files = []
         appendix = []
         for file in files:
@@ -719,7 +719,7 @@ class DjangoDocSection(DjangoDocElement):
             indices.update(test.test_indices())
         result = {}
         for index in indices:
-            result[index] = xml_data.get(
+            result[index] = doc_data.get(
                 (self.chapter.part.title, self.chapter.title, self.title, index)
             )
         return result
@@ -828,7 +828,7 @@ class DjangoDocSubsection(DjangoDocElement):
             indices.update(test.test_indices())
         result = {}
         for index in indices:
-            result[index] = xml_data.get(
+            result[index] = doc_data.get(
                 (self.chapter.part.title, self.chapter.title, self.title, index)
             )
         return result

--- a/mathics_django/docpipeline.py
+++ b/mathics_django/docpipeline.py
@@ -21,6 +21,7 @@ import mathics
 from mathics.core.definitions import Definitions
 from mathics.core.evaluation import Evaluation, Output
 from mathics.core.parser import MathicsSingleLineFeeder
+from mathics.doc.common_doc import MathicsMainDocumentation
 from mathics.builtin import builtins_dict
 
 from mathics import version_string
@@ -40,7 +41,7 @@ sep = "-" * 70 + "\n"
 
 # Global variables
 definitions = None
-documentation = None
+documentation = MathicsMainDocumentation()
 check_partial_enlapsed_time = False
 logfile = None
 
@@ -293,7 +294,6 @@ def test_all(
     doc_even_if_error=False,
     excludes=[],
 ):
-    global documentation
     if not quiet:
         print(f"Testing {version_string}")
 
@@ -393,11 +393,9 @@ def main():
     from mathics.doc import documentation as main_mathics_documentation
 
     global definitions
-    global documentation
     global logfile
     global check_partial_enlapsed_time
     definitions = Definitions(add_builtin=True)
-    documentation = main_mathics_documentation
 
     parser = ArgumentParser(description="Mathics test suite.", add_help=False)
     parser.add_argument(

--- a/mathics_django/web/media/js/.gitignore
+++ b/mathics_django/web/media/js/.gitignore
@@ -1,0 +1,1 @@
+/mathics-threejs-backend


### PR DESCRIPTION
* `.gitignore`: ignore files derived from mathics-threejs-backend
* `django_doc.py`: variable rename: xml_data -> doc_data
* `docpipeline.py`: Mathics core no longer (and dangerously/inefficiently) initializes doc data when the module is loaded. So this needs to be done explicitly.