### PR TITLE
More of the same

### DIFF
--- a/mathics_django/docpipeline.py
+++ b/mathics_django/docpipeline.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# FIXME: combine with same thing in Mathics Django
 """
 Does 2 things which can either be done independently or
 as a pipeline:
@@ -26,7 +27,7 @@ from mathics.builtin import builtins_dict
 
 from mathics import version_string
 
-from mathics_django.settings import DOC_XML_DATA_PATH
+from mathics_django.settings import DOC_DATA_PATH
 
 
 builtins = builtins_dict()
@@ -50,8 +51,8 @@ MAX_TESTS = 100000  # Number than the total number of tests
 
 
 def print_and_log(*args):
-    global logfile
-    string = "".join(args)
+    a = [a.decode("utf-8") if isinstance(a, bytes) else a for a in args]
+    string = "".join(a)
     print(string)
     if logfile:
         logfile.write(string)
@@ -87,15 +88,19 @@ def test_case(test, tests, index=0, subindex=0, quiet=False, section=None):
     def fail(why):
         part, chapter, section = tests.part, tests.chapter, tests.section
         print_and_log(
-            "%sTest failed: %s in %s / %s\n%s\n%s\n"
-            % (sep, section, part, chapter, test, why)
+            f"""{sep}Test failed: {section} in {part} / {chapter}
+{part}
+{why}
+""".encode(
+                "utf-8"
+            )
         )
         return False
 
     if not quiet:
         if section:
-            print("%s %s / %s %s" % (stars, tests.chapter, section, stars))
-        print("%4d (%2d): TEST %s" % (index, subindex, test))
+            print(f"{stars} {tests.chapter} / {section} {stars}".encode("utf-8"))
+        print(f"{index:4d} ({subindex:2d}): TEST {test}".encode("utf-8"))
 
     feeder = MathicsSingleLineFeeder(test, "<test>")
     evaluation = Evaluation(definitions, catch_interrupt=False, output=TestOutput())
@@ -189,21 +194,24 @@ def test_tests(
 
 
 # FIXME: move this to common routine
-def create_output(tests, output, format="xml"):
+def create_output(tests, doc_data, format="xml"):
     definitions.reset_user_definitions()
     for test in tests.tests:
         if test.private:
             continue
         key = test.key
         evaluation = Evaluation(
-            definitions, format=format, catch_interrupt=False, output=TestOutput()
+            definitions, format=format, catch_interrupt=True, output=TestOutput()
         )
-        result = evaluation.parse_evaluate(test.test)
+        try:
+            result = evaluation.parse_evaluate(test.test)
+        except:
+            result = None
         if result is None:
             result = []
         else:
             result = [result.get_data()]
-        output[key] = {
+        doc_data[key] = {
             "query": test.test,
             "results": result,
         }
@@ -218,11 +226,18 @@ def test_chapters(
 ):
     failed = 0
     index = 0
-    print(f'Testing chapter(s): {", ".join(chapters)}')
-    output_tex = load_doc_data() if reload else {}
+    chapter_names = ", ".join(chapters)
+    print(f"Testing chapter(s): {chapter_names}")
+    output_data = load_doc_data() if reload else {}
+    prev_key = []
     for tests in documentation.get_tests():
         if tests.chapter in chapters:
             for test in tests.tests:
+                key = list(test.key)[1:-1]
+                if prev_key != key:
+                    prev_key = key
+                    print(f'Testing section: {" / ".join(key)}')
+                    index = 0
                 if test.ignore:
                     continue
                 index += 1
@@ -231,13 +246,15 @@ def test_chapters(
                     if stop_on_failure:
                         break
             if generate_output and failed == 0:
-                create_output(tests, output_tex)
+                create_output(tests, output_data)
 
     print()
-    if failed > 0:
+    if index == 0:
+        print_and_log(f"No chapters found named {chapter_names}.")
+    elif failed > 0:
         print_and_log("%d test%s failed." % (failed, "s" if failed != 1 else ""))
     else:
-        print_and_log("OK")
+        print_and_log("All tests passed.")
 
 
 def test_sections(
@@ -249,12 +266,19 @@ def test_sections(
 ):
     failed = 0
     index = 0
-    print(f'Testing section(s): {", ".join(sections)}')
+    section_names = ", ".join(sections)
+    print(f"Testing section(s): {section_names}")
     sections |= {"$" + s for s in sections}
-    output_xml = load_doc_data() if reload else {}
+    output_data = load_doc_data() if reload else {}
+    prev_key = []
     for tests in documentation.get_tests():
         if tests.section in sections:
             for test in tests.tests:
+                key = list(test.key)[1:-1]
+                if prev_key != key:
+                    prev_key = key
+                    print(f'Testing section: {" / ".join(key)}')
+                    index = 0
                 if test.ignore:
                     continue
                 index += 1
@@ -263,15 +287,17 @@ def test_sections(
                     if stop_on_failure:
                         break
             if generate_output and failed == 0:
-                create_output(tests, output_xml)
+                create_output(tests, output_data)
 
     print()
-    if failed > 0:
+    if index == 0:
+        print_and_log(f"No sections found named {section_names}.")
+    elif failed > 0:
         print_and_log("%d test%s failed." % (failed, "s" if failed != 1 else ""))
     else:
-        print_and_log("OK")
+        print_and_log("All tests passed.")
     if generate_output and (failed == 0):
-        save_doc_data(output_xml)
+        save_doc_data(output_data)
 
 
 def open_ensure_dir(f, *args, **kwargs):
@@ -301,7 +327,7 @@ def test_all(
         index = 0
         total = failed = skipped = 0
         failed_symbols = set()
-        output_xml = {}
+        output_data = {}
         for tests in documentation.get_tests():
             sub_total, sub_failed, sub_skipped, symbols, index = test_tests(
                 tests,
@@ -313,7 +339,7 @@ def test_all(
                 excludes=excludes,
             )
             if generate_output:
-                create_output(tests, output_xml)
+                create_output(tests, output_data)
             total += sub_total
             failed += sub_failed
             skipped += sub_skipped
@@ -347,7 +373,7 @@ def test_all(
             print_and_log("  - %s in %s / %s" % (section, part, chapter))
 
     if generate_output and (failed == 0 or doc_even_if_error):
-        save_doc_data(output_xml)
+        save_doc_data(output_data)
         return True
 
     if failed == 0:
@@ -358,43 +384,40 @@ def test_all(
 
 
 def load_doc_data():
-    print(f"Loading XML data from {DOC_XML_DATA_PATH}")
-    with open_ensure_dir(DOC_XML_DATA_PATH, "rb") as xml_data_file:
-        return pickle.load(xml_data_file)
+    print(f"Loading internal document data from {DOC_DATA_PATH}")
+    with open_ensure_dir(DOC_DATA_PATH, "rb") as doc_data_file:
+        return pickle.load(doc_data_file)
 
 
-def save_doc_data(output_xml):
-    print(f"Writing XML data to {DOC_XML_DATA_PATH}")
-    with open_ensure_dir(DOC_XML_DATA_PATH, "wb") as output_file:
-        pickle.dump(output_xml, output_file, 4)
+def save_doc_data(output_data):
+    print(f"Writing internal document data to {DOC_DATA_PATH}")
+    with open_ensure_dir(DOC_DATA_PATH, "wb") as output_file:
+        pickle.dump(output_data, output_file, 4)
 
 
 def extract_doc_from_source(quiet=False, reload=False):
     """
-    Write internal (pickled) XML doc files and example data in docstrings.
+    Write internal (pickled) doc files and example data in docstrings.
     """
     if not quiet:
         print(f"Extracting internal doc data for {version_string}")
         print("This may take a while...")
 
     try:
-        output_xml = load_doc_data() if reload else {}
+        output_data = load_doc_data() if reload else {}
         for tests in documentation.get_tests():
-            create_output(tests, output_xml)
+            create_output(tests, output_data)
     except KeyboardInterrupt:
         print("\nAborted.\n")
         return
 
     print("done.\n")
-    save_doc_data(output_xml)
+    save_doc_data(output_data)
 
 
 def main():
-    from mathics.doc import documentation as main_mathics_documentation
-
-    global definitions
-    global logfile
     global check_partial_enlapsed_time
+    global definitions
     definitions = Definitions(add_builtin=True)
 
     parser = ArgumentParser(description="Mathics test suite.", add_help=False)
@@ -456,7 +479,7 @@ def main():
         "-o",
         dest="output",
         action="store_true",
-        help="generate XML output data",
+        help="generate pickled internal document data",
     )
     parser.add_argument(
         "--reload",
@@ -469,7 +492,7 @@ def main():
         "--doc-only",
         dest="doc_only",
         action="store_true",
-        help="generate XML output data without running tests",
+        help="reload pickled internal document data, before possibly adding to it",
     )
     parser.add_argument(
         "--quiet", "-q", dest="quiet", action="store_true", help="hide passed tests"
@@ -500,6 +523,9 @@ def main():
         default=MAX_TESTS,
         help="run only  N tests",
     )
+
+    global logfile
+
     args = parser.parse_args()
 
     if args.enlapsed_times:

--- a/mathics_django/settings.py
+++ b/mathics_django/settings.py
@@ -53,7 +53,7 @@ MATHICS_DJANGO_DB_PATH = os.environ.get(
 DOC_DIR = os.path.join(MATHICS_ROOT_DIR, "doc/documentation/")
 
 # Location for XML document data
-DOC_XML_DATA_PATH = os.path.join(DATA_DIR, "doc_xml_data.pcl")
+DOC_DATA_PATH = os.path.join(DATA_DIR, "doc_xml_data.pcl")
 
 
 DATABASES = {

--- a/mathics_django/web/templates/about.html
+++ b/mathics_django/web/templates/about.html
@@ -85,7 +85,7 @@
 					<li>Root Directory: <code>{{RootDirectory}}</code></li>
 					<li>Temporary Directory: <code>{{TemporaryDirectory}}</code></li>
 					<li>Database File: <code>{{DB_PATH}}</code></li>
-					<li>Document XML Data: <code>{{DOC_XML_DATA_PATH}}</code></li>
+					<li>Document Data: <code>{{DOC_DATA_PATH}}</code></li>
 				</ul>
 			</p>
 

--- a/mathics_django/web/views.py
+++ b/mathics_django/web/views.py
@@ -33,7 +33,7 @@ from mathics_django.doc.django_doc import (
     DjangoDocChapter,
     DjangoDocSection,
 )
-from mathics_django.settings import DOC_XML_DATA_PATH, MATHICS_DJANGO_DB_PATH
+from mathics_django.settings import DOC_DATA_PATH, MATHICS_DJANGO_DB_PATH
 from mathics_django.version import __version__
 from mathics_django.web.forms import LoginForm, SaveForm
 from mathics_django.web.models import Query, Worksheet, get_session_evaluation
@@ -164,7 +164,7 @@ def about_view(request):
             "RootDirectory": system_info["$RootDirectory"],
             "TemporaryDirectory": system_info["$TemporaryDirectory"],
             "DB_PATH": MATHICS_DJANGO_DB_PATH,
-            "DOC_XML_DATA_PATH": DOC_XML_DATA_PATH,
+            "DOC_DATA_PATH": DOC_DATA_PATH,
             "HTTP_USER_AGENT": request.META.get("HTTP_USER_AGENT", ""),
             "REMOTE_USER": request.META.get("REMOTE_USER", ""),
             "REMOTE_ADDR": request.META.get("REMOTE_ADDR", ""),


### PR DESCRIPTION
@TiagoCavalcanteTrindade  with some of the recent changes on the Mathics doc side, some of showing previously-computed examples is broken. 

Fixing that (at least as well as it is now done on the Mathics core side) will be done in another PR. After this, I'd like to make sure the revision numbers get back into "about" 

I'll be doing a docker update with all of this today, after improving PyPI docker configs.