### PR TITLE
Add summary text in section lists

### DIFF
--- a/mathics_django/web/templates/doc/section.html
+++ b/mathics_django/web/templates/doc/section.html
@@ -13,8 +13,12 @@
 
 	{% if section.subsections %}
 	   <ul>
-		{% for subsection in section.subsections %}
-			<li>{{ subsection|link:ajax }}</li>
+		   {% for subsection in section.subsections %}
+		      {% if subsection.summary_text %}
+		         <li>{{ subsection|link:ajax }} &mdash; <i>{{subsection.summary_text}}</i></li>
+              {% else %}
+		         <li>{{ subsection|link:ajax }}</li>
+		   	  {% endif %}
 		{% endfor %}
 	   </ul>
 	{% endif %}


### PR DESCRIPTION
There is a branch in Mathics core of the same name that starts to add the actual description text.