### PR TITLE
Dup settings

### DIFF
--- a/admin-tools/make-dist.sh
+++ b/admin-tools/make-dist.sh
@@ -18,21 +18,15 @@ fi
 cd ..
 source mathics_django/version.py
 echo $__version__
+cp -v ${HOME}/.local/var/mathics/doc_html_data.pcl mathics_django/doc/
 
-for pyversion in $PYVERSIONS; do
-	if ! pyenv local $pyversion ; then
-	exit $?
-	fi
-	# pip bdist_egg create too-general wheels. So
-	# we narrow that by moving the generated wheel.
-
-	# pick out first two number of version, e.g. 3.7.9 -> 37
-	first_two=$(echo $pyversion | cut -d'.' -f 1-2 | sed -e 's/\.//')
-	rm -fr build
-	python setup.py bdist_egg
-	python setup.py bdist_wheel
-	python setup.py bdist_wheel --universal
-	mv -v dist/${PACKAGE}-$VERSION-{py2.py3,py$first_two}-none-any.whl
-done
+# for pyversion in $PYVERSIONS; do
+# 	if ! pyenv local $pyversion ; then
+# 	exit $?
+# 	fi
+# 	rm -fr build
+# 	python setup.py bdist_egg
+# 	python setup.py bdist_wheel
+# done
 
 python ./setup.py sdist

--- a/mathics_django/doc/django_doc.py
+++ b/mathics_django/doc/django_doc.py
@@ -14,7 +14,9 @@ More importantly, this code should be replaced by Sphinx and autodoc.
 
 from os import listdir
 from types import ModuleType
+
 import importlib
+import os.path as osp
 import re
 
 from django.utils.safestring import mark_safe
@@ -23,7 +25,7 @@ from mathics import builtin, settings
 from mathics.builtin import get_module_doc
 
 from mathics_django.doc.utils import escape_html
-from mathics_django.settings import DOC_DATA_PATH
+from mathics_django.settings import get_doc_html_data_path
 
 from mathics.doc.common_doc import (
     CHAPTER_RE,
@@ -45,10 +47,11 @@ import pickle
 
 # FIXME: remove globalness
 try:
-    with open(DOC_DATA_PATH, "rb") as doc_data_file:
+    doc_data_path = get_doc_html_data_path(should_be_readable=True)
+    with open(doc_data_path, "rb") as doc_data_file:
         doc_data = pickle.load(doc_data_file)
 except IOError:
-    print(f"Trouble reading Doc file {DOC_DATA_PATH}")
+    print(f"Trouble reading Doc file {doc_data_path}")
     doc_data = {}
 
 
@@ -215,7 +218,6 @@ class Documentation(DjangoDocElement):
 
 class MathicsMainDocumentation(Documentation):
     def __init__(self):
-        self.doc_data_file = DOC_DATA_PATH
         self.doc_dir = settings.DOC_DIR
         self.parts = []
         self.parts_by_slug = {}
@@ -230,7 +232,7 @@ class MathicsMainDocumentation(Documentation):
             if part_title.endswith(".mdoc"):
                 part_title = part_title[: -len(".mdoc")]
                 part = DjangoDocPart(self, part_title)
-                text = open(self.doc_dir + file, "rb").read().decode("utf8")
+                text = open(osp.join(self.doc_dir, file), "rb").read().decode("utf8")
                 text = filter_comments(text)
                 chapters = CHAPTER_RE.findall(text)
                 for title, text in chapters:

--- a/mathics_django/docpipeline.py
+++ b/mathics_django/docpipeline.py
@@ -27,7 +27,7 @@ from mathics.builtin import builtins_dict
 
 from mathics import version_string
 
-from mathics_django.settings import DOC_DATA_PATH
+from mathics_django.settings import get_doc_html_data_path
 
 
 builtins = builtins_dict()
@@ -384,14 +384,18 @@ def test_all(
 
 
 def load_doc_data():
-    print(f"Loading internal document data from {DOC_DATA_PATH}")
-    with open_ensure_dir(DOC_DATA_PATH, "rb") as doc_data_file:
+    doc_html_data_path = get_doc_html_data_path(should_be_readable=True)
+    print(f"Loading internal document data from {doc_html_data_path}")
+    with open_ensure_dir(doc_html_data_path, "rb") as doc_data_file:
         return pickle.load(doc_data_file)
 
 
 def save_doc_data(output_data):
-    print(f"Writing internal document data to {DOC_DATA_PATH}")
-    with open_ensure_dir(DOC_DATA_PATH, "wb") as output_file:
+    doc_html_data_path = get_doc_html_data_path(
+        should_be_readable=False, create_parent=True
+    )
+    print(f"Writing internal document data to {doc_html_data_path}")
+    with open_ensure_dir(doc_html_data_path, "wb") as output_file:
         pickle.dump(output_data, output_file, 4)
 
 

--- a/mathics_django/settings.py
+++ b/mathics_django/settings.py
@@ -40,7 +40,7 @@ DOC_USER_HTML_DATA_PATH = osp.join(DATA_DIR, "doc_html_data.pcl")
 
 # We need another version as a fallback, and that is distributed with the
 # package. It is note user writable and not in the user space.
-DOC_SYSTEM_HTML_DATA_PATH = osp.join(ROOT_DIR, "data", "doc_html_data.pcl")
+DOC_SYSTEM_HTML_DATA_PATH = osp.join(ROOT_DIR, "doc", "doc_html_data.pcl")
 
 
 def get_doc_html_data_path(should_be_readable=False, create_parent=False) -> str:

--- a/mathics_django/version.py
+++ b/mathics_django/version.py
@@ -4,4 +4,4 @@
 # well as importing into Python. That's why there is no
 # space around "=" below.
 # fmt: off
-__version__="3.1.1.dev0"  # noqa
+__version__="4.0.0.dev0"  # noqa

--- a/mathics_django/web/views.py
+++ b/mathics_django/web/views.py
@@ -38,7 +38,7 @@ from mathics_django.doc.django_doc import (
     DjangoDocChapter,
     DjangoDocSection,
 )
-from mathics_django.settings import DOC_DATA_PATH, MATHICS_DJANGO_DB_PATH
+from mathics_django.settings import DOC_USER_HTML_DATA_PATH, MATHICS_DJANGO_DB_PATH
 from mathics_django.version import __version__
 from mathics_django.web.forms import LoginForm, SaveForm
 from mathics_django.web.models import Query, Worksheet, get_session_evaluation
@@ -93,7 +93,7 @@ def about_view(request):
             "RootDirectory": system_info["$RootDirectory"],
             "TemporaryDirectory": system_info["$TemporaryDirectory"],
             "DB_PATH": MATHICS_DJANGO_DB_PATH,
-            "DOC_DATA_PATH": DOC_DATA_PATH,
+            "DOC_DATA_PATH": DOC_USER_HTML_DATA_PATH,
             "HTTP_USER_AGENT": request.META.get("HTTP_USER_AGENT", ""),
             "REMOTE_USER": request.META.get("REMOTE_USER", ""),
             "REMOTE_ADDR": request.META.get("REMOTE_ADDR", ""),

--- a/setup.py
+++ b/setup.py
@@ -149,7 +149,7 @@ setup(
     dependency_links=DEPENDENCY_LINKS,
     package_data={
         "mathics_django.autoload": ["autoload/*.m"],
-        "mathics_django.doc": ["documentation/*.mdoc", "xml/data"],
+        "mathics_django.doc": ["*.pcl"],
         "mathics_django.web": [
             "media/css/*.css",
             "media/img/*.*",
@@ -176,6 +176,7 @@ setup(
     zip_safe=False,
     # metadata for upload to PyPI
     maintainer="Mathics Group",
+    maintainer_email="mathics-devel@googlegroups.com",
     description="A Django front end for Mathics.",
     license="GPL",
     url="https://mathics.org/",


### PR DESCRIPTION
Revise doc data for HTML
    
We now keep both a version of the internal docs for LaTeX formatting in both package space and user space.
    
User space is writable and can be updated with additional modules as might be found in PyMathics modules one day
    
The system space is a fallback and is supplied by the distribution. It has document data at the time the distribution was packaged.
    
Note that data destined for HTML needs to be separate.
    
The main difference is that the output results format are different. LaTeX/asymptote versus HTML/MathJax/ThreeJS.
    
Simple, huh?
