### PR TITLE
Section title snuck in again...

### DIFF
--- a/mathics_django/doc/.gitignore
+++ b/mathics_django/doc/.gitignore
@@ -1,0 +1,1 @@
+/doc_html_data.pcl

--- a/mathics_django/doc/django_doc.py
+++ b/mathics_django/doc/django_doc.py
@@ -624,11 +624,12 @@ class DjangoDoc(XMLDoc):
     def html(self):
         counters = {}
         items = [item for item in self.items if not item.is_private()]
-        if len(items) and items[0].text.startswith(self.title):
+        title_line = self.title + "\n"
+        if len(items) and items[0].text.startswith(title_line):
             # In module-style docstring tagging, the first line of the docstring is the section title.
             # since that is tagged and shown as a title, it is redundant here is the section body.
             # Or that is the intent. This code is a bit hacky.
-            items = items[1:]
+            items[0].text = items[0].text[len(title_line):]
 
         text = "\n".join(item.html(counters) for item in items if not item.is_private())
         if text == "":


### PR DESCRIPTION
In Mathics core when the regexp for test got more stringent we a no
longer treating the section title as a test.

Adjust for this.