### PR TITLE
Packging woes - release 4.0.1

### DIFF
--- a/admin-tools/make-dist.sh
+++ b/admin-tools/make-dist.sh
@@ -22,7 +22,7 @@ cp -v ${HOME}/.local/var/mathics/doc_html_data.pcl mathics_django/doc/
 
 for pyversion in $PYVERSIONS; do
 	if ! pyenv local $pyversion ; then
-	exit $?
+		exit $?
 	fi
 	rm -fr build
 	python setup.py bdist_egg

--- a/mathics_django/version.py
+++ b/mathics_django/version.py
@@ -4,4 +4,4 @@
 # well as importing into Python. That's why there is no
 # space around "=" below.
 # fmt: off
-__version__="4.0.0"  # noqa
+__version__="4.0.1"  # noqa

--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,7 @@ setup(
     extras_require=EXTRA_REQUIRES,
     dependency_links=DEPENDENCY_LINKS,
     package_data={
-        "mathics_django.autoload": ["autoload/*.m"],
+        "mathics_django": ["autoload/*.m"],
         "mathics_django.doc": ["*.pcl"],
         "mathics_django.web": [
             "media/css/*.css",


### PR DESCRIPTION
We weren't packaging autoload/settings.m

(This and a bug in Mathics core is keeping omnibus from working properly)

Will probably do another Mathics-Django release after this clears. Mathics-core release will probably happen next weekend.