### PR TITLE
Remove `os` from strategy matrix in OSX workflow

### DIFF
--- a/.github/workflows/osx.yaml
+++ b/.github/workflows/osx.yaml
@@ -11,7 +11,6 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        os: [macOS]
         python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
That wasn't used.