### PR TITLE
Allow hiding startup message via URL query param

### DIFF
--- a/mathics_django/web/media/js/mathics.js
+++ b/mathics_django/web/media/js/mathics.js
@@ -783,7 +783,17 @@ function domLoaded() {
 
 	MathJax.Hub.Configured();
 
-	if (localStorage.getItem('hideMathicsStartupMsg') === 'true') {
+	function shouldHideStartup() {
+		if (localStorage.getItem('hideMathicsStartupMsg') === 'true') {
+			return true;
+		}
+		let params = new URLSearchParams(document.location.search);
+		if (params.get("hide_startup_msg") == "true") {
+			return true;
+		}
+		return false;
+	}
+	if (shouldHideStartup()) {
 		document.getElementById('welcome').style.display = 'none';
 	}
 


### PR DESCRIPTION
Hi I'm using Mathics inside a webview that doesn't support cookies/local storage.

Unfortunately, my local development environment is broken (for mathics),
so I haven't been able to test this (the javascript doesn't update).
However, this is a very simple change so I'm pretty sure it'll work (the javascript function 'shouldHideStartup()' does work in my simple smoke-tesets).

I'll work on my developer environment, but maybe you could consider accepting this anyways? I'd be happy to make a second PR to fix any bugs that showup.....

Also here's a link to the webview app (https://github.com/Techcable/mathicsd). I'm planning to do a public release soonish (it still needs a few minor tweaks :wink:).

