### PR TITLE
Allow text for URL links

### DIFF
--- a/mathics_django/doc/utils.py
+++ b/mathics_django/doc/utils.py
@@ -125,7 +125,13 @@ def escape_html(text, verbatim_mode=False, counters=None, single_line=False):
             if tag == "em":
                 return r"<em>%s</em>" % content
             elif tag == "url":
-                return r'<a href="%s">%s</a>' % (content, content)
+                try:
+                    text = match.group("text")
+                except IndexError:
+                    text = None
+                if text is None:
+                    text = content
+                return r'<a href="%s">%s</a>' % (content, text)
 
         text = HYPERTEXT_RE.sub(repl_hypertext, text)
 


### PR DESCRIPTION
This is the Django part of https://github.com/Mathics3/mathics-core/pull/473

@TiagoCavalcante this reminds me that master is still broken for threejs. This weekend I plan on doing a general release. If we don't have something in place by then I'll go with graphics3d-fixup and we will have to deal with the custom shader version later.  It has now been months that this has been broken.  Whatever speedups or niceties there have been by using a custom shader seem to be way offset by the time and aggravation and breakage by this often not working.