### PR TITLE
fixes OutputForm[...] and FullForm[...] results

### DIFF
--- a/mathics_django/web/format.py
+++ b/mathics_django/web/format.py
@@ -64,8 +64,8 @@ def format_output(obj, expr, format=None):
             expr = elements[0]
 
     if expr_type in ("System`FullForm", "System`OutputForm"):
-        result = Expression(SymbolStandardForm, expr).format(obj, expr_type)
-        return str(result)
+        result = expr.elements[0].format(obj, expr_type)
+        return result.boxes_to_text()
     elif expr_type == "System`Graphics":
         result = Expression(SymbolStandardForm, expr).format(obj, "System`MathMLForm")
 


### PR DESCRIPTION
This PR fixes the routine that formats the output, for the case of  `FullForm` and `OutputForm`. In master, 
```
OutputForm[f[x+b]]
```
produces
```
RowBox[List[(<string: "standardform"="">, <string: "["="">, RowBox[List[(<string: "fullform"="">, <string: "["="">, RowBox[List[(<string: "f"="">, <string: "["="">, RowBox[List[(<string: "plus"="">, <string: "["="">, RowBox[List[(<string: "b"="">, <string: ",="" "="">, <string: "x"="">)]], <string: "]"="">)]], <string: "]"="">)]], <string: "]"="">)]], <string: "]"="">)]]</string:></string:></string:></string:></string:></string:></string:></string:></string:></string:></string:></string:></string:></string:></string:>
```

With this fix, the string `f[x+b]` is shown.