### PR TITLE
More ENV vars and fix HTTP {404,500}

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,16 @@
 CHANGES
 =======
 
+5.1.0.dev
+-----
+
+* Environment variables which change Django settings (also shown under Settings)
+  - ``MATHICS_DJANGO_ALLOWED_HOSTS`` sets Django ``ALLOWED_HOST``; use semicolon to separate entries
+  - ``MATHICS_DJANGO_DEBUG_HOSTS`` sets Django ``DEBUG``
+  - ``MATHICS_DJANGO_DDISPLAY_EXCEPTIONS_HOSTS`` sets Django ``DISPLAY_EXCEPTIONS``
+
+* Adjust for Mathics3 core 5.0.3 API
+
 5.0.0
 -----
 

--- a/mathics_django/settings.py
+++ b/mathics_django/settings.py
@@ -6,10 +6,24 @@ import os.path as osp
 from mathics.settings import DATA_DIR
 from pathlib import Path
 
-DEBUG = True
+debug_str = os.environ.get("MATHICS_DJANGO_DEBUG", "true")
+DEBUG = debug_str.lower().strip() in ("true", "t", "1", "yes")
+
+# The environment variable MATHICS_DJANGO_ALLOWED_HOSTS is used
+# to set Django's ALLOWED_HOST, which specifies what kinds of
+# host/domain names that Django can serve.
+# See:
+#   https://docs.djangoproject.com/en/4.1/ref/settings/#allowed-hosts
+# for details
+allowed_host_list = os.environ.get("MATHICS_DJANGO_ALLOWED_HOSTS", None)
+if allowed_host_list is not None:
+    ALLOWED_HOSTS = allowed_host_list.split(";")
+else:
+    # Use Django's default value for ALLOWED_HOSTS.
+    ALLOWED_HOSTS = []
 
 # set only to True in DEBUG mode
-DISPLAY_EXCEPTIONS = True
+DISPLAY_EXCEPTIONS = os.environ.get("MATHICS_DJANGO_DISPLAY_EXCEPTIONS", True)
 
 LOG_QUERIES = False
 

--- a/mathics_django/version.py
+++ b/mathics_django/version.py
@@ -4,4 +4,4 @@
 # well as importing into Python. That's why there is no
 # space around "=" below.
 # fmt: off
-__version__="5.0.0"  # noqa
+__version__="5.1.0.dev"  # noqa

--- a/mathics_django/web/templates/404.html
+++ b/mathics_django/web/templates/404.html
@@ -1,5 +1,5 @@
-{% extends "base.html" %}
-
 {% block content %}
-	<h1>Page not found</h1>
+<h1>Page not found</h1>
+<p>URI: {{request_path}}</p>
+<p>Sorry - no angry unicorn logos here. They are out to pasture.</p>
 {% endblock content %}

--- a/mathics_django/web/templates/500.html
+++ b/mathics_django/web/templates/500.html
@@ -1,5 +1,6 @@
-{% extends "base.html" %}
-
 {% block content %}
-	<h1>Server error</h1>
+<h1>Server error</h1>
+<p>URI: {{request_path}}</p>
+<p>Sorry - no angry unicorn logos here. They are out to pasture.</p>
 {% endblock content %}
+{% extends "base.html" %}

--- a/mathics_django/web/templates/about.html
+++ b/mathics_django/web/templates/about.html
@@ -49,6 +49,16 @@
 
 
 			<h1>Settings</h1>
+
+			<h2>Django</h2>
+			<ul>
+				<li><code>ALLOWED_HOSTS</code>: <code>{{settings.ALLOWED_HOSTS}}</code></li>
+				<li><code>DEBUG</code>: <code>{{settings.DEBUG}}</code></li>
+				<li><code>DISPLAY_EXCEPTIONS</code>: <code>{{settings.DISPLAY_EXCEPTIONS}}</code></li>
+			</ul>
+
+
+			<h2>Mathics Django</h2>
 			<p>
 				<ul>
 				{% for setting, value in user_settings.items %}

--- a/mathics_django/web/views.py
+++ b/mathics_django/web/views.py
@@ -74,38 +74,39 @@ def about_view(request):
         request,
         "about.html",
         {
-            "django_version": django_version,
-            "three_js_version": get_threejs_version(),
-            "mathics_threejs_backend_version": get_mathics_threejs_backend_version(),
-            "MathJax_version": get_MathJax_version(),
-            "mathics_version": mathics_version_info["mathics"],
-            "mathics_django_version": __version__,
-            "mpmath_version": mathics_version_info["mpmath"],
-            "numpy_version": mathics_version_info["numpy"],
-            "python_version": mathics_version_info["python"],
-            "sympy_version": mathics_version_info["sympy"],
-            "SystemID": system_info["$SystemID"],
-            "SystemTimeZone": system_info["$SystemTimeZone"],
-            "UserName": system_info["$UserName"],
             "BaseDirectory": system_info["$BaseDirectory"],
-            "HomeDirectory": system_info["$HomeDirectory"],
-            "InstallationDirectory": system_info["$InstallationDirectory"],
-            "RootDirectory": system_info["$RootDirectory"],
-            "TemporaryDirectory": system_info["$TemporaryDirectory"],
             "DB_PATH": MATHICS_DJANGO_DB_PATH,
             "DOC_DATA_PATH": DOC_USER_HTML_DATA_PATH,
             "HTTP_USER_AGENT": request.META.get("HTTP_USER_AGENT", ""),
-            "REMOTE_USER": request.META.get("REMOTE_USER", ""),
-            "REMOTE_ADDR": request.META.get("REMOTE_ADDR", ""),
-            "REMOTE_HOST": request.META.get("REMOTE_HOST", ""),
-            "MachinePrecision": system_info["MachinePrecision"],
-            "MemoryAvailable": system_info["MemoryAvailable[]"],
-            "SystemMemory": system_info["$SystemMemory"],
+            "HomeDirectory": system_info["$HomeDirectory"],
+            "InstallationDirectory": system_info["$InstallationDirectory"],
             "Machine": system_info["$Machine"],
             "MachineName": system_info["$MachineName"],
+            "MachinePrecision": system_info["MachinePrecision"],
+            "MathJax_version": get_MathJax_version(),
+            "MemoryAvailable": system_info["MemoryAvailable[]"],
             "ProcessID": system_info["$ProcessID"],
             "ProcessorType": system_info["$ProcessorType"],
             "PythonVersion": sys.version,
+            "REMOTE_ADDR": request.META.get("REMOTE_ADDR", ""),
+            "REMOTE_HOST": request.META.get("REMOTE_HOST", ""),
+            "REMOTE_USER": request.META.get("REMOTE_USER", ""),
+            "RootDirectory": system_info["$RootDirectory"],
+            "SystemID": system_info["$SystemID"],
+            "SystemMemory": system_info["$SystemMemory"],
+            "SystemTimeZone": system_info["$SystemTimeZone"],
+            "TemporaryDirectory": system_info["$TemporaryDirectory"],
+            "UserName": system_info["$UserName"],
+            "django_version": django_version,
+            "mathics_django_version": __version__,
+            "mathics_threejs_backend_version": get_mathics_threejs_backend_version(),
+            "mathics_version": mathics_version_info["mathics"],
+            "mpmath_version": mathics_version_info["mpmath"],
+            "numpy_version": mathics_version_info["numpy"],
+            "python_version": mathics_version_info["python"],
+            "settings": settings,
+            "sympy_version": mathics_version_info["sympy"],
+            "three_js_version": get_threejs_version(),
             "user_settings": get_user_settings(evaluation),
         },
     )
@@ -294,31 +295,12 @@ def email_user(user, subject, text):
 
 def error_404_view(request, exception):
     t = loader.get_template("404.html")
-    return HttpResponseNotFound(
-        t.render(
-            RequestContext(
-                request,
-                {
-                    "title": "Page not found",
-                    "request_path": request.path,
-                },
-            )
-        )
-    )
+    return HttpResponseNotFound(t.render({"request_path": request.path}))
 
 
 def error_500_view(request):
     t = loader.get_template("500.html")
-    return HttpResponseServerError(
-        t.render(
-            RequestContext(
-                request,
-                {
-                    "title": "Server error",
-                },
-            )
-        )
-    )
+    return HttpResponseServerError(t.render({"request_path": request.path}))
 
 
 def get_MathJax_version():


### PR DESCRIPTION
* Environment variables which change Django settings (also shown under Settings)
  - ``MATHICS_DJANGO_ALLOWED_HOSTS`` sets Django ``ALLOWED_HOST``; use semicolon to separate entries
  - ``MATHICS_DJANGO_DEBUG_HOSTS`` sets Django ``DEBUG``
  - ``MATHICS_DJANGO_DDISPLAY_EXCEPTIONS_HOSTS`` sets Django ``DISPLAY_EXCEPTIONS``

HTTP 404 and 500 rendering fixed. We had holdover code from Django 1.6!