### PR TITLE
Fix empty session_key on new sessions

### DIFF
--- a/mathics_django/web/models.py
+++ b/mathics_django/web/models.py
@@ -22,6 +22,7 @@ _evaluations = {}
 def get_session_evaluation(session):
     evaluation = _evaluations.get(session.session_key)
     if evaluation is None:
+        session.create()
         definitions = Definitions(add_builtin=True)
         # We set the formatter to "unformatted" so that we can use
         # our own custom formatter that understand better how to format


### PR DESCRIPTION
The session was being shared by everyone because `session.session_key` was `None` when accessing the `_evaluations` dictionary.

From what I experimented this fixes #169.