### PR TITLE
Better error handling

### DIFF
--- a/mathics_django/web/media/js/mathics.js
+++ b/mathics_django/web/media/js/mathics.js
@@ -1,829 +1,862 @@
 // TODO: getSelection function
+// -*- mode: js; js-indent-level: 4; -*-
+
 
 let deleting,
-	blurredElement,
-	movedItem,
-	clickedQuery,
-	lastFocus = null,
-	welcome = true,
-	queryIndex = 0,
-	mouseDownEvent = null,
-	timeout = -1;
+    blurredElement,
+    movedItem,
+    clickedQuery,
+    lastFocus = null,
+    welcome = true,
+    queryIndex = 0,
+    mouseDownEvent = null,
+    timeout = -1;
 
 function getLetterWidth(element) {
-	const letter = document.createElement('span');
-	letter.innerText = 'm';
-	letter.style.fontFamily = element.style.fontFamily;
-	letter.style.fontSize = element.style.fontSize;
+    const letter = document.createElement('span');
+    letter.innerText = 'm';
+    letter.style.fontFamily = element.style.fontFamily;
+    letter.style.fontSize = element.style.fontSize;
 
-	document.body.appendChild(letter);
+    document.body.appendChild(letter);
 
-	const width = letter.getWidth();
+    const width = letter.getWidth();
 
-	document.body.removeChild(letter);
+    document.body.removeChild(letter);
 
-	return width;
+    return width;
 }
 
 function refreshInputSize(textarea) {
-	const letterWidth = getLetterWidth(textarea),
-		width = textarea.clientWidth,
-		lines = textarea.value.split('\n');
+    const letterWidth = getLetterWidth(textarea),
+          width = textarea.clientWidth,
+          lines = textarea.value.split('\n');
 
-	let lineCount = 0;
+    let lineCount = 0;
 
-	lines.forEach((line) => {
-		lineCount += Math.ceil((line.length + 1) * letterWidth / width);
-	});
+    lines.forEach((line) => {
+        lineCount += Math.ceil((line.length + 1) * letterWidth / width);
+    });
 
-	textarea.rows = lineCount;
+    textarea.rows = lineCount;
 }
 
 function refreshInputSizes() {
-	document.querySelectorAll('textarea.request').forEach(
-		(textarea) => refreshInputSize(textarea)
-	);
+    document.querySelectorAll('textarea.request').forEach(
+        (textarea) => refreshInputSize(textarea)
+    );
 }
 
 function inputChange() {
-	refreshInputSize(this);
+    refreshInputSize(this);
 }
 
 function isEmpty(textarea) {
-	return textarea.value.strip() == '' && !textarea.submitted;
+    return textarea.value.strip() == '' && !textarea.submitted;
 }
 
 function prepareText(text) {
-	return text || String.fromCharCode(160); // non breaking space, like &nbsp;
+    return text || String.fromCharCode(160); // non breaking space, like &nbsp;
 }
 
 function getDimensions(math, callback) {
-	const all = document.getElementById('calc_all').cloneNode(true);
-	all.id = null;
+    const all = document.getElementById('calc_all').cloneNode(true);
+    all.id = null;
 
-	document.body.appendChild(all);
-	const container = all.querySelector('.calc_container');
-	container.appendChild(translateDOMElement(math));
+    document.body.appendChild(all);
+    const container = all.querySelector('.calc_container');
+    container.appendChild(translateDOMElement(math));
 
-	MathJax.Hub.Queue(['Typeset', MathJax.Hub, container]);
-	MathJax.Hub.Queue(() => {
-		const containerOffsetLeft = container.offsetLeft,
-			containerOffsetTop = container.offsetTop,
-			nextOffsetLeft = all.querySelector('.calc_next').offsetLeft,
-			belowOffsetTop = all.querySelector('.calc_below').offsetTop;
+    MathJax.Hub.Queue(['Typeset', MathJax.Hub, container]);
+    MathJax.Hub.Queue(() => {
+        const containerOffsetLeft = container.offsetLeft,
+              containerOffsetTop = container.offsetTop,
+              nextOffsetLeft = all.querySelector('.calc_next').offsetLeft,
+              belowOffsetTop = all.querySelector('.calc_below').offsetTop;
 
-		const width = nextOffsetLeft - containerOffsetLeft + 4,
-			height = belowOffsetTop - containerOffsetTop + 20;
+        const width = nextOffsetLeft - containerOffsetLeft + 4,
+              height = belowOffsetTop - containerOffsetTop + 20;
 
-		all.remove();
+        all.remove();
 
-		callback(width, height);
-	});
+        callback(width, height);
+    });
 }
 
 function createMathNode(nodeName) {
-	if (['svg', 'g', 'rect', 'circle', 'polyline', 'polygon', 'path', 'ellipse', 'foreignObject'].include(nodeName)) {
-		return document.createElementNS("http://www.w3.org/2000/svg", nodeName);
-	}
+    if (['svg', 'g', 'rect', 'circle', 'polyline', 'polygon', 'path', 'ellipse', 'foreignObject'].include(nodeName)) {
+        return document.createElementNS("http://www.w3.org/2000/svg", nodeName);
+    }
 
-	return document.createElement(nodeName);
+    return document.createElement(nodeName);
 }
 
 let objectsPrefix = 'math_object_', objectsCount = 0, objects = {};
 
 function translateDOMElement(element, svg) {
-	if (element.nodeType === 3) {
-		return document.createTextNode(element.nodeValue);
-	}
+    if (element.nodeType === 3) {
+        return document.createTextNode(element.nodeValue);
+    }
 
-	const nodeName = element.nodeName;
+    const nodeName = element.nodeName;
 
-	let dom = null;
+    let dom = null;
 
-	if (nodeName !== 'meshgradient' && nodeName !== 'graphics3d') {
-		dom = createMathNode(element.nodeName);
+    if (nodeName !== 'meshgradient' && nodeName !== 'graphics3d') {
+        dom = createMathNode(element.nodeName);
 
-		for (let i = 0; i < element.attributes.length; i++) {
-			const attr = element.attributes[i];
+        for (let i = 0; i < element.attributes.length; i++) {
+            const attr = element.attributes[i];
 
-			if (attr.nodeName != 'ox' && attr.nodeName != 'oy') {
-				dom.setAttribute(attr.nodeName, attr.nodeValue);
-			}
-		}
-	}
+            if (attr.nodeName != 'ox' && attr.nodeName != 'oy') {
+                dom.setAttribute(attr.nodeName, attr.nodeValue);
+            }
+        }
+    }
 
-	if (nodeName === 'foreignObject') {
-		dom.setAttribute('width', svg.getAttribute('width'));
-		dom.setAttribute('height', svg.getAttribute('height'));
-		dom.setAttribute('style', dom.getAttribute('style') + '; text-align: left; padding-left: 2px; padding-right: 2px;');
+    if (nodeName === 'foreignObject') {
+        dom.setAttribute('width', svg.getAttribute('width'));
+        dom.setAttribute('height', svg.getAttribute('height'));
+        dom.setAttribute('style', dom.getAttribute('style') + '; text-align: left; padding-left: 2px; padding-right: 2px;');
 
-		dom.setAttribute('ox', parseFloat(element.getAttribute('ox')));
-		dom.setAttribute('oy', parseFloat(element.getAttribute('oy')));
-	}
+        dom.setAttribute('ox', parseFloat(element.getAttribute('ox')));
+        dom.setAttribute('oy', parseFloat(element.getAttribute('oy')));
+    }
 
-	if (nodeName === 'mo') {
-		const op = element.firstChild.nodeValue;
+    if (nodeName === 'mo') {
+        const op = element.firstChild.nodeValue;
 
-		if (op === '[' ||
-			op === ']' ||
-			op === '{' ||
-			op === '}' ||
-			op === String.fromCharCode(12314) ||
-			op === String.fromCharCode(12315)
-		) {
-			dom.setAttribute('maxsize', '3');
-		}
-	}
+        if (op === '[' ||
+            op === ']' ||
+            op === '{' ||
+            op === '}' ||
+            op === String.fromCharCode(12314) ||
+            op === String.fromCharCode(12315)
+           ) {
+            dom.setAttribute('maxsize', '3');
+        }
+    }
 
-	let object = null;
+    let object = null;
 
-	if (nodeName === 'graphics3d') {
-		const data = JSON.parse(element.getAttribute('data')),
-			div = document.createElement('div');
+    if (nodeName === 'graphics3d') {
+        const data = JSON.parse(element.getAttribute('data')),
+              div = document.createElement('div');
 
-		drawGraphics3d(div, data);
+        drawGraphics3d(div, data);
 
-		dom = div;
-	}
+        dom = div;
+    }
 
-	if (nodeName === 'svg' || nodeName === 'graphics3d' || nodeName.toLowerCase() === 'img') {
-		// create <mspace> that will contain the graphics
-		object = createMathNode('mspace');
+    if (nodeName === 'svg' || nodeName === 'graphics3d' || nodeName.toLowerCase() === 'img') {
+        // create <mspace> that will contain the graphics
+        object = createMathNode('mspace');
 
-		let width, height;
+        let width, height;
 
-		if (nodeName === 'svg' || nodeName.toLowerCase() === 'img') {
-			width = dom.getAttribute('width');
-			height = dom.getAttribute('height');
+        if (nodeName === 'svg' || nodeName.toLowerCase() === 'img') {
+            width = dom.getAttribute('width');
+            height = dom.getAttribute('height');
 
-			if (!width.endsWith('px')) {
-				width += 'px';
-			}
+            if (!width.endsWith('px')) {
+                width += 'px';
+            }
 
-			if (!height.endsWith('px')) {
-				height += 'px';
-			}
-		} else {
-			// TODO: calculate appropriate height and recalculate on every view change
-			width = height = '400px';
-		}
+            if (!height.endsWith('px')) {
+                height += 'px';
+            }
+        } else {
+            // TODO: calculate appropriate height and recalculate on every view change
+            width = height = '400px';
+        }
 
-		object.setAttribute('width', width);
-		object.setAttribute('height', height);
-	}
+        object.setAttribute('width', width);
+        object.setAttribute('height', height);
+    }
 
-	if (nodeName === 'svg') {
-		svg = dom;
-	}
+    if (nodeName === 'svg') {
+        svg = dom;
+    }
 
-	let rows = [[]];
+    let rows = [[]];
 
-	element.childNodes.forEach((child) => {
-		if (child.nodeName == 'mspace' && child.getAttribute('linebreak') == 'newline') {
-			rows.push([]);
-		} else {
-			rows[rows.length - 1].push(child);
-		}
-	});
+    element.childNodes.forEach((child) => {
+        if (child.nodeName == 'mspace' && child.getAttribute('linebreak') == 'newline') {
+            rows.push([]);
+        } else {
+            rows[rows.length - 1].push(child);
+        }
+    });
 
-	let childParent = dom;
+    let childParent = dom;
 
-	if (nodeName === 'math') {
-		const mstyle = createMathNode('mstyle');
-		mstyle.setAttribute('displaystyle', 'true');
+    if (nodeName === 'math') {
+        const mstyle = createMathNode('mstyle');
+        mstyle.setAttribute('displaystyle', 'true');
 
-		dom.appendChild(mstyle);
+        dom.appendChild(mstyle);
 
-		childParent = mstyle;
-	}
+        childParent = mstyle;
+    }
 
-	if (rows.length > 1) {
-		const nospace = 'cell-spacing: 0; cell-padding: 0; row-spacing: 0; row-padding: 0; border-spacing: 0; padding: 0; margin: 0';
+    if (rows.length > 1) {
+        const nospace = 'cell-spacing: 0; cell-padding: 0; row-spacing: 0; row-padding: 0; border-spacing: 0; padding: 0; margin: 0';
 
-		const mtable = createMathNode('mtable');
-		mtable.setAttribute('rowspacing', '0');
-		mtable.setAttribute('columnalign', 'left');
-		mtable.setAttribute('style', nospace);
+        const mtable = createMathNode('mtable');
+        mtable.setAttribute('rowspacing', '0');
+        mtable.setAttribute('columnalign', 'left');
+        mtable.setAttribute('style', nospace);
 
-		rows.forEach((row) => {
-			const mtr = createMathNode('mtr'),
-				mtd = createMathNode('mtd');
+        rows.forEach((row) => {
+            const mtr = createMathNode('mtr'),
+                  mtd = createMathNode('mtd');
 
-			mtr.setAttribute('style', nospace);
-			mtd.setAttribute('style', nospace);
+            mtr.setAttribute('style', nospace);
+            mtd.setAttribute('style', nospace);
 
-			row.forEach((element) => {
-				const elmt = translateDOMElement(element, svg);
+            row.forEach((element) => {
+                const elmt = translateDOMElement(element, svg);
 
-				if (nodeName == 'mtext') {
-					// wrap element in mtext
-					const outer = createMathNode('mtext');
-					outer.appendChild(elmt);
+                if (nodeName == 'mtext') {
+                    // wrap element in mtext
+                    const outer = createMathNode('mtext');
+                    outer.appendChild(elmt);
 
-					elmt = outer;
-				}
+                    elmt = outer;
+                }
 
-				mtd.appendChild(elmt);
-			});
+                mtd.appendChild(elmt);
+            });
 
-			mtr.appendChild(mtd);
-			mtable.appendChild(mtr);
-		});
+            mtr.appendChild(mtd);
+            mtable.appendChild(mtr);
+        });
 
-		if (nodeName === 'mtext') {
-			// no mtable inside mtext, but mtable instead of mtext
-			dom = mtable;
-		} else {
-			childParent.appendChild(mtable);
-		}
-	} else {
-		rows[0].forEach(
-			(element) => childParent.appendChild(
-				translateDOMElement(element, svg)
-			)
-		);
-	}
+        if (nodeName === 'mtext') {
+            // no mtable inside mtext, but mtable instead of mtext
+            dom = mtable;
+        } else {
+            childParent.appendChild(mtable);
+        }
+    } else {
+        rows[0].forEach(
+            (element) => childParent.appendChild(
+                translateDOMElement(element, svg)
+            )
+        );
+    }
 
-	if (object) {
-		const id = objectsCount++;
+    if (object) {
+        const id = objectsCount++;
 
-		object.setAttribute('id', objectsPrefix + id);
-		objects[id] = dom;
+        object.setAttribute('id', objectsPrefix + id);
+        objects[id] = dom;
 
-		return object;
-	}
+        return object;
+    }
 
-	return dom;
+    return dom;
 }
 
 function createLine(value) {
-	const container = document.createElement('div');
-	container.innerHTML = value;
+    const container = document.createElement('div');
+    container.innerHTML = value;
 
-	if (container?.firstElementChild?.tagName === 'math') {
-		return translateDOMElement(container.firstChild);
-	} else if (container?.firstElementChild?.tagName === 'GRAPHICS3D') {
-		const div = document.createElement('div');
+    if (container?.firstElementChild?.tagName === 'math') {
+        return translateDOMElement(container.firstChild);
+    } else if (container?.firstElementChild?.tagName === 'GRAPHICS3D') {
+        const div = document.createElement('div');
 
-		drawGraphics3d(div, JSON.parse(container.firstElementChild.attributes.data.value));
+        drawGraphics3d(div, JSON.parse(container.firstElementChild.attributes.data.value));
 
-		div.style.overflow = 'hidden';
-		div.style.position = 'relative';
-		div.style.margin = 'auto';
+        div.style.overflow = 'hidden';
+        div.style.position = 'relative';
+        div.style.margin = 'auto';
 
-		return div;
-	} else if (container?.firstElementChild?.tagName === 'svg') {
-		container.firstElementChild.style.display = 'block';
-		container.firstElementChild.style.width = '100%';
-		container.firstElementChild.style.maxWidth = '400px';
-		container.firstElementChild.style.margin = 'auto';
+        return div;
+    } else if (container?.firstElementChild?.tagName === 'svg') {
+        container.firstElementChild.style.display = 'block';
+        container.firstElementChild.style.width = '100%';
+        container.firstElementChild.style.maxWidth = '400px';
+        container.firstElementChild.style.margin = 'auto';
 
-		return container;
-	} else {
-		const lines = container.innerHTML.split('\n');
+        return container;
+    } else {
+        const lines = container.innerHTML.split('\n');
 
-		const p = document.createElement('p');
-		p.className = 'string';
+        const p = document.createElement('p');
+        p.className = 'string';
 
-		for (let i = 0; i < lines.length; i++) {
-			p.innerText += prepareText(lines[i]);
+        for (let i = 0; i < lines.length; i++) {
+            p.innerText += prepareText(lines[i]);
 
-			if (i < lines.length - 1) {
-				p.appendChild(document.createElement('br'));
-			}
-		}
+            if (i < lines.length - 1) {
+                p.appendChild(document.createElement('br'));
+            }
+        }
 
-		return p;
-	}
+        return p;
+    }
 }
 
 function afterProcessResult(list, command) {
-	// command is either 'Typeset' (default) or 'Rerender'
-	command ||= 'Typeset';
+    // command is either 'Typeset' (default) or 'Rerender'
+    command ||= 'Typeset';
 
-	MathJax.Hub.Queue([command, MathJax.Hub, list]);
-	MathJax.Hub.Queue(() => {
-		// inject SVG and other non-MathML objects into corresponding <mspace>s
-		list.querySelectorAll('.mspace').forEach((mspace) => {
-			const id = mspace.getAttribute('id').substr(objectsPrefix.length);
+    MathJax.Hub.Queue([command, MathJax.Hub, list]);
+    MathJax.Hub.Queue(() => {
+        // inject SVG and other non-MathML objects into corresponding <mspace>s
+        list.querySelectorAll('.mspace').forEach((mspace) => {
+            const id = mspace.getAttribute('id').substr(objectsPrefix.length);
 
-			mspace.appendChild(objects[id]);
-		});
-	});
+            mspace.appendChild(objects[id]);
+        });
+    });
 
-	if (!MathJax.Hub.Browser.isOpera) {
-		// Opera 11.01 Build 1190 on Mac OS X 10.5.8 crashes on this call for Plot[x,{x,0,1}]
-		// => leave inner MathML untouched
-		MathJax.Hub.Queue(['Typeset', MathJax.Hub, list]);
-	}
+    if (!MathJax.Hub.Browser.isOpera) {
+        // Opera 11.01 Build 1190 on Mac OS X 10.5.8 crashes on this call for Plot[x,{x,0,1}]
+        // => leave inner MathML untouched
+        MathJax.Hub.Queue(['Typeset', MathJax.Hub, list]);
+    }
 
-	MathJax.Hub.Queue(() => {
-		list.querySelectorAll('foreignObject > span > nobr > span.math')
-			.forEach((math) => {
-				const content = math.firstChild.firstChild.firstChild;
+    MathJax.Hub.Queue(() => {
+        list.querySelectorAll('foreignObject > span > nobr > span.math')
+            .forEach((math) => {
+                const content = math.firstChild.firstChild.firstChild;
 
-				math.removeChild(math.firstChild);
-				math.insertBefore(content, math.firstChild);
+                math.removeChild(math.firstChild);
+                math.insertBefore(content, math.firstChild);
 
-				if (command === 'Typeset') {
-					// recalculate positions of insets based on ox/oy properties
-					const foreignObject = math.parentNode.parentNode.parentNode,
-						dimensions = math.getDimensions();
+                if (command === 'Typeset') {
+                    // recalculate positions of insets based on ox/oy properties
+                    const foreignObject = math.parentNode.parentNode.parentNode,
+                          dimensions = math.getDimensions();
 
-					const ox = parseFloat(foreignObject.getAttribute('ox')),
-						oy = parseFloat(foreignObject.getAttribute('oy')),
-						width = dimensions.width + 4,
-						height = dimensions.height + 4;
+                    const ox = parseFloat(foreignObject.getAttribute('ox')),
+                          oy = parseFloat(foreignObject.getAttribute('oy')),
+                          width = dimensions.width + 4,
+                          height = dimensions.height + 4;
 
-					let x = parseFloat(foreignObject.getAttribute('x').substr()),
-						y = parseFloat(foreignObject.getAttribute('y'));
+                    let x = parseFloat(foreignObject.getAttribute('x').substr()),
+                        y = parseFloat(foreignObject.getAttribute('y'));
 
-					x = x - width / 2.0 - ox * width / 2.0;
-					y = y - height / 2.0 + oy * height / 2.0;
+                    x = x - width / 2.0 - ox * width / 2.0;
+                    y = y - height / 2.0 + oy * height / 2.0;
 
-					foreignObject.setAttribute('x', x + 'px');
-					foreignObject.setAttribute('y', y + 'px');
-				}
-			});
-	});
+                    foreignObject.setAttribute('x', x + 'px');
+                    foreignObject.setAttribute('y', y + 'px');
+                }
+            });
+    });
 }
 
 function setResult(list, results) {
-	const resultList = document.createElement('ul');
-	resultList.className = 'out';
-	// we'll just show if it have children
-	resultList.style.display = 'none';
+    // Formats DJango cell "results" and add that onto "list".
 
-	results.forEach((result) => {
-		result.out.forEach((out) => {
-			const li = document.createElement('li');
-			li.className = out.message ? 'message' : 'print';
+    const resultList = document.createElement('ul');
+    resultList.className = 'out';
 
-			if (out.message) {
-				li.innerHTML += out.prefix + ': ';
-			}
+    resultList.style.display = 'none';
 
-			li.appendChild(createLine(out.text));
+    const li = document.createElement('li');
+    li.className = 'out';
 
-			resultList.appendChild(li);
-		});
+    if (results.length == 1 && results[0].form == "SyntaxError") {
+        const result = results[0];
+        const out = result.out[0];
 
-		if (result.result) {
-			const li = document.createElement('li');
-			li.className = 'result';
-			li.appendChild(createLine(result.result));
+	// Syntax Error prefix or code
+        const bold = document.createElement('b');
+        bold.className = "message"
+        bold.innerHTML = out.prefix + ":"
+        resultList.appendChild(bold)
 
-			resultList.appendChild(li);
-			resultList.style.display = 'block';
-		}
 
-		if (result.out.length) {
-			resultList.style.display = 'block';
-		}
-	});
+	// Syntax Error message
+        const pre = document.createElement('pre');
+        pre.innerHTML = out.text
 
-	const li = document.createElement('li');
-	li.className = 'out';
-	li.appendChild(resultList);
+	// Add this to a list element in a block (which is CSS styled with a nice
+	// frame around it.
+        resultList.appendChild(pre)
+        resultList.style.display = 'block';
+        li.appendChild(resultList);
+        list.appendChild(li);
 
-	list.appendChild(li);
+    } else {
+        results.forEach((result) => {
 
-	afterProcessResult(list);
+            result.out.forEach((out) => {
+                const li = document.createElement('li');
+                li.className = out.message ? 'message' : 'print';
+
+                if (out.message) {
+                    li.innerHTML += out.prefix + ': ';
+                }
+
+                li.appendChild(createLine(out.text));
+
+                resultList.appendChild(li);
+            });
+
+            if (result.result) {
+                const li = document.createElement('li');
+                li.className = 'result';
+                li.appendChild(createLine(result.result));
+
+                resultList.appendChild(li);
+                resultList.style.display = 'block';
+            }
+
+            if (result.out.length) {
+                resultList.style.display = 'block';
+            }
+        });
+
+
+	// Add this to a list element in a block (which is CSS styled with a nice
+	// frame around it.
+        li.appendChild(resultList);
+        list.appendChild(li);
+
+	// rocky: I think this is gross that we post-process the list. But so be it.
+        afterProcessResult(list);
+    }
 }
 
 function submitQuery(element, onfinish, query) {
-	if (welcome) {
-		document.getElementById('welcomeContainer')?.fade({ duration: 0.2 });
+    if (welcome) {
+        document.getElementById('welcomeContainer')?.fade({ duration: 0.2 });
 
-		if (document.getElementById('hideStartupMsg')?.checked) {
-			localStorage.setItem('hideMathicsStartupMsg', 'true');
-		}
+        if (document.getElementById('hideStartupMsg')?.checked) {
+            localStorage.setItem('hideMathicsStartupMsg', 'true');
+        }
 
-		welcome = false;
-		document.getElementById('logo').classList.remove('load');
-	}
+        welcome = false;
+        document.getElementById('logo').classList.remove('load');
+    }
 
-	element.li?.classList.add('loading');
-	document.getElementById('logo')?.classList.add('working');
+    element.li?.classList.add('loading');
+    document.getElementById('logo')?.classList.add('working');
 
-	new Ajax.Request('/ajax/query/', {
-		method: 'post',
-		parameters: { query: query || element.value },
-		onSuccess: (transport) => {
-			if (element.ul) {
-				element.ul.select('li[class!=request][class!=submitbutton]')
-					.forEach((element) => element.remove());
+    new Ajax.Request('/ajax/query/', {
+        method: 'post',
+        parameters: { query: query || element.value },
+        onSuccess: (transport) => {
+            if (element.ul) {
+                element.ul.select('li[class!=request][class!=submitbutton]')
+                    .forEach((element) => element.remove());
 
-				if (!transport.responseText) {
-					// a fatal Python error has occurred, e.g. on 4.4329408320439^43214234345
-					// ("Fatal Python error: mp_reallocate failure")
-					// -> print overflow message
-					transport.responseText = '{"results": [{"out": [{"prefix": "General::noserver", "message": true, "tag": "noserver", "symbol": "General", "text": "<math><mrow><mtext>No server running.</mtext></mrow></math>"}]}]}';
-				}
+                if (!transport.responseText) {
+                    // a fatal Python error has occurred, e.g. on 4.4329408320439^43214234345
+                    // ("Fatal Python error: mp_reallocate failure")
+                    // -> print overflow message
+                    transport.responseText = '{"results": [{"out": [{"prefix": "General::noserver", "message": true, "tag": "noserver", "symbol": "General", "text": "<math><mrow><mtext>No server running.</mtext></mrow></math>"}]}]}';
+                }
 
-				const response = JSON.parse(transport.responseText);
+                const response = JSON.parse(transport.responseText);
 
-				setResult(element.ul, response.results);
-				element.submitted = true;
-				element.results = response.results;
+                setResult(element.ul, response.results);
+                element.submitted = true;
+                element.results = response.results;
 
-				const next = element.li.nextSibling;
+                const next = element.li.nextSibling;
 
-				if (next) {
-					next.textarea.focus();
-				} else {
-					createQuery();
-				}
-			}
-		},
-		onFailure: () => {
-			element?.ul.select('li[class!=request]')
-				.forEach((element) => element.remove());
+                if (next) {
+                    next.textarea.focus();
+                } else {
+                    createQuery();
+                }
+            }
+        },
+        onFailure: () => {
+            element?.ul.select('li[class!=request]')
+                .forEach((element) => element.remove());
 
-			const li = document.createElement('li');
-			li.className = 'serverError';
-			li.innerText = 'Sorry, an error occurred while processing your request!';
+            const li = document.createElement('li');
+            li.className = 'serverError';
+            li.innerText = 'Sorry, an error occurred while processing your request!';
 
-			element?.ul.appendChild(li);
-			element.submitted = true;
-		},
-		onComplete: () => {
-			element?.li.classList.remove('loading');
-			document.getElementById('logo')?.classList.remove('working');
+            element?.ul.appendChild(li);
+            element.submitted = true;
+        },
+        onComplete: () => {
+            element?.li.classList.remove('loading');
+            document.getElementById('logo')?.classList.remove('working');
 
-			if (onfinish) {
-				onfinish();
-			}
-		}
-	});
+            if (onfinish) {
+                onfinish();
+            }
+        }
+    });
 }
 
 function keyDown(event) {
-	const textArea = lastFocus;
+    const textArea = lastFocus;
 
-	if (!textArea) {
-		return;
-	}
+    if (!textArea) {
+        return;
+    }
 
-	refreshInputSize(textArea);
+    refreshInputSize(textArea);
 
-	if (event.key === 'Enter' && (event.shiftKey || event.location === 3)) {
-		event.stop();
+    if (event.key === 'Enter' && (event.shiftKey || event.location === 3)) {
+        event.stop();
 
-		if (textArea.value.strip()) {
-			submitQuery(textArea);
-		}
-	} else if (event.key === 'ArrowUp') {
-		if (textArea.selectionStart === 0 && textArea.selectionEnd === 0) {
-			if (isEmpty(textArea)) {
-				if (textArea.li.previousSibling) {
-					textArea.li.previousSibling.textarea.focus();
-				}
-			} else {
-				createQuery(textArea.li);
-			}
-		}
-	} else if (event.key === 'ArrowDown') {
-		if (textArea.selectionStart === textArea.value.length && textArea.selectionEnd === textArea.selectionStart) {
-			if (isEmpty(textArea)) {
-				if (textArea.li.nextSibling) {
-					textArea.li.nextSibling.textarea.focus();
-				}
-			} else {
-				createQuery(textArea.li.nextSibling);
-			}
-		}
-	} else if (isGlobalKey(event)) {
-		event.stop();
-		event.stopPropagation();
-		event.preventDefault();
-	}
+        if (textArea.value.strip()) {
+            submitQuery(textArea);
+        }
+    } else if (event.key === 'ArrowUp') {
+        if (textArea.selectionStart === 0 && textArea.selectionEnd === 0) {
+            if (isEmpty(textArea)) {
+                if (textArea.li.previousSibling) {
+                    textArea.li.previousSibling.textarea.focus();
+                }
+            } else {
+                createQuery(textArea.li);
+            }
+        }
+    } else if (event.key === 'ArrowDown') {
+        if (textArea.selectionStart === textArea.value.length && textArea.selectionEnd === textArea.selectionStart) {
+            if (isEmpty(textArea)) {
+                if (textArea.li.nextSibling) {
+                    textArea.li.nextSibling.textarea.focus();
+                }
+            } else {
+                createQuery(textArea.li.nextSibling);
+            }
+        }
+    } else if (isGlobalKey(event)) {
+        event.stop();
+        event.stopPropagation();
+        event.preventDefault();
+    }
 }
 
 function deleteMouseDown(event) {
-	if (event.isLeftClick()) {
-		deleting = true;
-	}
+    if (event.isLeftClick()) {
+        deleting = true;
+    }
 }
 
 function deleteClick() {
-	if (lastFocus === this.li.textarea) {
-		lastFocus = null;
-	}
+    if (lastFocus === this.li.textarea) {
+        lastFocus = null;
+    }
 
-	this.li.remove();
-	deleting = false;
+    this.li.remove();
+    deleting = false;
 
-	if (blurredElement) {
-		blurredElement.focus();
-		blurredElement = null;
-	}
+    if (blurredElement) {
+        blurredElement.focus();
+        blurredElement = null;
+    }
 
-	if (document.getElementById('queries').childElementCount === 0) {
-		createQuery();
-	}
+    if (document.getElementById('queries').childElementCount === 0) {
+        createQuery();
+    }
 }
 
 function moveMouseDown() {
-	movedItem = this.li;
-	movedItem.addClassName('moving');
+    movedItem = this.li;
+    movedItem.addClassName('moving');
 }
 
 function moveMouseUp() {
-	if (movedItem) {
-		movedItem.classList.remove('moving');
-		movedItem.textarea.focus();
-		movedItem = null;
-	}
+    if (movedItem) {
+        movedItem.classList.remove('moving');
+        movedItem.textarea.focus();
+        movedItem = null;
+    }
 }
 
 function onFocus() {
-	this.li.classList.add('focused');
-	lastFocus = this;
+    this.li.classList.add('focused');
+    lastFocus = this;
 }
 
 function onBlur() {
-	blurredElement = this;
+    blurredElement = this;
 
-	if (!deleting &&
-		this.li != movedItem &&
-		isEmpty(this) &&
-		document.getElementById('queries').childElementCount > 1
-	) {
-		this.li.display = 'none';
+    if (!deleting &&
+        this.li != movedItem &&
+        isEmpty(this) &&
+        document.getElementById('queries').childElementCount > 1
+       ) {
+        this.li.display = 'none';
 
-		if (this == lastFocus) {
-			lastFocus = null;
-		}
+        if (this == lastFocus) {
+            lastFocus = null;
+        }
 
-		this.li.remove();
-	}
+        this.li.remove();
+    }
 
-	this.li.classList.remove('focused');
+    this.li.classList.remove('focused');
 }
 
 function createSortable() {
-	Position.includeScrollOffsets = true;
-	Sortable.create('queries', {
-		handle: 'move',
-		scroll: 'document',
-		scrollSensitivity: 1 // otherwise strange flying-away of item at top
-	});
+    Position.includeScrollOffsets = true;
+    Sortable.create('queries', {
+        handle: 'move',
+        scroll: 'document',
+        scrollSensitivity: 1 // otherwise strange flying-away of item at top
+    });
 }
 
 function createQuery(beforeElement, noFocus, updatingAll) {
-	const textarea = document.createElement('textarea');
-	textarea.className = 'request';
-	textarea.spellcheck = false;
-	textarea.rows = 1;
+    const textarea = document.createElement('textarea');
+    textarea.className = 'request';
+    textarea.spellcheck = false;
+    textarea.rows = 1;
 
-	const submitButton = document.createElement('span');
-	submitButton.innerText = '=';
+    const submitButton = document.createElement('span');
+    submitButton.innerText = '=';
 
-	const submitButtonBox = document.createElement('span');
-	submitButtonBox.className = 'submitbutton';
-	submitButtonBox.title = 'Evaluate [Shift+Return]';
-	submitButtonBox.appendChild(submitButton);
+    const submitButtonBox = document.createElement('span');
+    submitButtonBox.className = 'submitbutton';
+    submitButtonBox.title = 'Evaluate [Shift+Return]';
+    submitButtonBox.appendChild(submitButton);
 
-	const request = document.createElement('li');
-	request.className = 'request';
-	request.appendChild(textarea);
-	request.appendChild(submitButtonBox);
+    const request = document.createElement('li');
+    request.className = 'request';
+    request.appendChild(textarea);
+    request.appendChild(submitButtonBox);
 
-	const ul = document.createElement('ul');
-	ul.className = 'query';
-	ul.appendChild(request);
+    const ul = document.createElement('ul');
+    ul.className = 'query';
+    ul.appendChild(request);
 
-	const moveHandle = document.createElement('span');
-	moveHandle.className = 'move';
+    const moveHandle = document.createElement('span');
+    moveHandle.className = 'move';
 
-	const deleteHandle = document.createElement('span');
-	deleteHandle.className = 'delete';
-	deleteHandle.title = 'Delete';
-	deleteHandle.innerText = '×';
+    const deleteHandle = document.createElement('span');
+    deleteHandle.className = 'delete';
+    deleteHandle.title = 'Delete';
+    deleteHandle.innerText = '×';
 
-	// items need id in order for Sortable.onUpdate to work.
-	const li = document.createElement('li');
-	li.id = 'query_' + queryIndex++;
-	li.className = 'query';
-	li.appendChild(ul);
-	li.appendChild(moveHandle);
-	li.appendChild(deleteHandle);
+    // items need id in order for Sortable.onUpdate to work.
+    const li = document.createElement('li');
+    li.id = 'query_' + queryIndex++;
+    li.className = 'query';
+    li.appendChild(ul);
+    li.appendChild(moveHandle);
+    li.appendChild(deleteHandle);
 
-	textarea.ul = ul;
-	textarea.li = li;
-	textarea.submitted = false;
-	moveHandle.li = li;
-	deleteHandle.li = li;
-	li.textarea = textarea;
-	li.ul = ul;
+    textarea.ul = ul;
+    textarea.li = li;
+    textarea.submitted = false;
+    moveHandle.li = li;
+    deleteHandle.li = li;
+    li.textarea = textarea;
+    li.ul = ul;
 
-	const queries = document.getElementById('queries');
+    const queries = document.getElementById('queries');
 
-	if (beforeElement) {
-		queries.insertBefore(li, beforeElement);
-	} else {
-		queries.appendChild(li);
-	}
+    if (beforeElement) {
+        queries.insertBefore(li, beforeElement);
+    } else {
+        queries.appendChild(li);
+    }
 
-	if (!updatingAll) {
-		refreshInputSize(textarea);
-	}
+    if (!updatingAll) {
+        refreshInputSize(textarea);
+    }
 
-	textarea.addEventListener('keyup', inputChange);
-	textarea.addEventListener('focus', onFocus);
-	textarea.addEventListener('blur', onBlur);
-	li.addEventListener('mousedown', queryMouseDown);
-	deleteHandle.addEventListener('click', deleteClick);
-	deleteHandle.addEventListener('mousedown', deleteMouseDown);
-	moveHandle.addEventListener('mousedown', moveMouseDown);
-	document.addEventListener('mouseup', moveMouseUp);
-	submitButton.addEventListener('mousedown', () => {
-		if (textarea.value.strip()) {
-			submitQuery(textarea);
-		} else {
-			textarea.focus();
-		}
-	});
+    textarea.addEventListener('keyup', inputChange);
+    textarea.addEventListener('focus', onFocus);
+    textarea.addEventListener('blur', onBlur);
+    li.addEventListener('mousedown', queryMouseDown);
+    deleteHandle.addEventListener('click', deleteClick);
+    deleteHandle.addEventListener('mousedown', deleteMouseDown);
+    moveHandle.addEventListener('mousedown', moveMouseDown);
+    document.addEventListener('mouseup', moveMouseUp);
+    submitButton.addEventListener('mousedown', () => {
+        if (textarea.value.strip()) {
+            submitQuery(textarea);
+        } else {
+            textarea.focus();
+        }
+    });
 
-	if (!updatingAll) {
-		createSortable();
-	}
+    if (!updatingAll) {
+        createSortable();
+    }
 
-	if (!noFocus) {
-		textarea.focus();
-	}
+    if (!noFocus) {
+        textarea.focus();
+    }
 
-	return li;
+    return li;
 }
 
 function documentMouseDown(event) {
-	if (event.isLeftClick()) {
-		if (clickedQuery) {
-			clickedQuery = null;
-			mouseDownEvent = null;
+    if (event.isLeftClick()) {
+        if (clickedQuery) {
+            clickedQuery = null;
+            mouseDownEvent = null;
 
-			return;
-		}
+            return;
+        }
 
-		mouseDownEvent = event;
-	}
+        mouseDownEvent = event;
+    }
 }
 
 function documentClick(event) {
-	const queries = document.getElementById('queries');
+    const queries = document.getElementById('queries');
 
-	// in Firefox, mousedown also fires when user clicks scrollbars.
-	// -> listen to click
-	event = mouseDownEvent;
+    // in Firefox, mousedown also fires when user clicks scrollbars.
+    // -> listen to click
+    event = mouseDownEvent;
 
-	if (!event) {
-		return;
-	}
+    if (!event) {
+        return;
+    }
 
-	if (queries.childElementCount === 1 && isEmpty(queries.firstElementChild.textarea)) {
-		queries.firstElementChild.textarea.focus();
+    if (queries.childElementCount === 1 && isEmpty(queries.firstElementChild.textarea)) {
+        queries.firstElementChild.textarea.focus();
 
-		return;
-	}
+        return;
+    }
 
-	const documentElement = document.getElementById('document');
-	const y = event.pointerY() - documentElement.offsetTop + documentElement.scrollTop;
+    const documentElement = document.getElementById('document');
+    const y = event.pointerY() - documentElement.offsetTop + documentElement.scrollTop;
 
-	let element = null;
+    let element = null;
 
-	for (let i = 0; i < queries.childElementCount; i++) {
-		// margin-top: 10px
-		if (queries.children[i].positionedOffset().top + 20 > y) {
-			element = queries.children[i];
+    for (let i = 0; i < queries.childElementCount; i++) {
+        // margin-top: 10px
+        if (queries.children[i].positionedOffset().top + 20 > y) {
+            element = queries.children[i];
 
-			break;
-		}
-	}
+            break;
+        }
+    }
 
-	createQuery(element);
+    createQuery(element);
 }
 
 function queryMouseDown() {
-	clickedQuery = this;
+    clickedQuery = this;
 }
 
 function focusLast() {
-	if (lastFocus) {
-		lastFocus.focus();
-	} else {
-		createQuery();
-	}
+    if (lastFocus) {
+        lastFocus.focus();
+    } else {
+        createQuery();
+    }
 }
 
 function isGlobalKey(event) {
-	if (event.ctrlKey) {
-		const key = event.key.toLowerCase();
+    if (event.ctrlKey) {
+        const key = event.key.toLowerCase();
 
-		if (key === 'd' || key === 's' || key === 'o') {
-			return true;
-		}
-	}
+        if (key === 'd' || key === 's' || key === 'o') {
+            return true;
+        }
+    }
 
-	return false;
+    return false;
 }
 
 function globalKeyUp(event) {
-	if (!popup && event.ctrlKey) {
-		switch (event.keyCode) {
-			case 68: // D
-				showDoc();
-				document.getElementById('search').select();
-				event.stop();
+    if (!popup && event.ctrlKey) {
+        switch (event.keyCode) {
+        case 68: // D
+            showDoc();
+            document.getElementById('search').select();
+            event.stop();
 
-				break;
-			// case 67: // C
-			// 	focusLast();
-			// 	event.stop();
-			// 
-			// 	break;
-			case 83: // S
-				event.stop();
-				event.stopPropagation();
-				event.preventDefault();
-				showSave();
+            break;
+        // case 67: // C
+        //      focusLast();
+        //      event.stop();
+        //
+        //      break;
+        case 83: // S
+            event.stop();
+            event.stopPropagation();
+            event.preventDefault();
+            showSave();
 
-				break;
-			case 79: // O
-				event.stop();
-				event.stopPropagation();
-				event.preventDefault();
-				showOpen();
+            break;
+        case 79: // O
+            event.stop();
+            event.stopPropagation();
+            event.preventDefault();
+            showOpen();
 
-				break;
-		}
-	}
+            break;
+        }
+    }
 }
 
 function domLoaded() {
-	MathJax.Hub.Config({
-		'HTML-CSS': {
-			imageFont: null,
-			linebreaks: {
-				automatic: true,
-				width: '70% container'
-			}
-		},
-		MMLorHTML: {
-			// the output jax that is to be preferred when both are possible
-			// (set to 'MML' for native MathML, 'HTML' for MathJax's HTML-CSS output jax).
-			prefer: {
-				MSIE: 'HTML',
-				Firefox: 'HTML',
-				Opera: 'HTML',
-				other: 'HTML'
-			}
-		}
-	});
+    MathJax.Hub.Config({
+        'HTML-CSS': {
+            imageFont: null,
+            linebreaks: {
+                automatic: true,
+                width: '70% container'
+            }
+        },
+        MMLorHTML: {
+            // the output jax that is to be preferred when both are possible
+            // (set to 'MML' for native MathML, 'HTML' for MathJax's HTML-CSS output jax).
+            prefer: {
+                MSIE: 'HTML',
+                Firefox: 'HTML',
+                Opera: 'HTML',
+                other: 'HTML'
+            }
+        }
+    });
 
-	MathJax.Hub.Configured();
+    MathJax.Hub.Configured();
 
-	if (localStorage.getItem('hideMathicsStartupMsg') === 'true') {
-		document.getElementById('welcome').style.display = 'none';
-	}
+    if (localStorage.getItem('hideMathicsStartupMsg') === 'true') {
+        document.getElementById('welcome').style.display = 'none';
+    }
 
-	const queriesContainer = document.getElementById('queriesContainer');
+    const queriesContainer = document.getElementById('queriesContainer');
 
-	if (queriesContainer) {
-		const queries = document.createElement('ul'),
-			documentElement = document.getElementById('document');
+    if (queriesContainer) {
+        const queries = document.createElement('ul'),
+              documentElement = document.getElementById('document');
 
-		queries.id = 'queries';
+        queries.id = 'queries';
 
-		queriesContainer.appendChild(queries);
+        queriesContainer.appendChild(queries);
 
-		documentElement.addEventListener('mousedown', documentMouseDown);
-		documentElement.addEventListener('click', documentClick);
+        documentElement.addEventListener('mousedown', documentMouseDown);
+        documentElement.addEventListener('click', documentClick);
 
-		document.addEventListener('keydown', keyDown);
-		window.addEventListener('keydown', globalKeyUp);
-		window.addEventListener('keyup', globalKeyUp);
+        document.addEventListener('keydown', keyDown);
+        window.addEventListener('keydown', globalKeyUp);
+        window.addEventListener('keyup', globalKeyUp);
 
-		if (!loadLink()) {
-			createQuery();
-		}
-	}
+        if (!loadLink()) {
+            createQuery();
+        }
+    }
 }
 
 window.addEventListener('DOMContentLoaded', domLoaded);
 window.addEventListener('resize', refreshInputSizes);
 
 window.addEventListener('resize', function () {
-	if (timeout >= 0) {
-		// the user is still resizing so postpone the action further
-		window.clearTimeout(timeout);
-	}
+    if (timeout >= 0) {
+        // the user is still resizing so postpone the action further
+        window.clearTimeout(timeout);
+    }
 
-	timeout = window.setTimeout(function () {
-		document.querySelectorAll('#queries ul').forEach((ul) => {
-			afterProcessResult(ul, 'Rerender');
-		});
+    timeout = window.setTimeout(function () {
+        document.querySelectorAll('#queries ul').forEach((ul) => {
+            afterProcessResult(ul, 'Rerender');
+        });
 
-		timeout = -1; // reset the timeout
-	}, 500);
+        timeout = -1; // reset the timeout
+    }, 500);
 });

--- a/mathics_django/web/media/js/mathics.js
+++ b/mathics_django/web/media/js/mathics.js
@@ -29,13 +29,13 @@ function getLetterWidth(element) {
 
 function refreshInputSize(textarea) {
     const letterWidth = getLetterWidth(textarea),
-          width = textarea.clientWidth,
-          lines = textarea.value.split('\n');
+	  width = textarea.clientWidth,
+	  lines = textarea.value.split('\n');
 
     let lineCount = 0;
 
     lines.forEach((line) => {
-        lineCount += Math.ceil((line.length + 1) * letterWidth / width);
+	lineCount += Math.ceil((line.length + 1) * letterWidth / width);
     });
 
     textarea.rows = lineCount;
@@ -43,7 +43,7 @@ function refreshInputSize(textarea) {
 
 function refreshInputSizes() {
     document.querySelectorAll('textarea.request').forEach(
-        (textarea) => refreshInputSize(textarea)
+	(textarea) => refreshInputSize(textarea)
     );
 }
 
@@ -69,23 +69,23 @@ function getDimensions(math, callback) {
 
     MathJax.Hub.Queue(['Typeset', MathJax.Hub, container]);
     MathJax.Hub.Queue(() => {
-        const containerOffsetLeft = container.offsetLeft,
-              containerOffsetTop = container.offsetTop,
-              nextOffsetLeft = all.querySelector('.calc_next').offsetLeft,
-              belowOffsetTop = all.querySelector('.calc_below').offsetTop;
+	const containerOffsetLeft = container.offsetLeft,
+	      containerOffsetTop = container.offsetTop,
+	      nextOffsetLeft = all.querySelector('.calc_next').offsetLeft,
+	      belowOffsetTop = all.querySelector('.calc_below').offsetTop;
 
-        const width = nextOffsetLeft - containerOffsetLeft + 4,
-              height = belowOffsetTop - containerOffsetTop + 20;
+	const width = nextOffsetLeft - containerOffsetLeft + 4,
+	      height = belowOffsetTop - containerOffsetTop + 20;
 
-        all.remove();
+	all.remove();
 
-        callback(width, height);
+	callback(width, height);
     });
 }
 
 function createMathNode(nodeName) {
     if (['svg', 'g', 'rect', 'circle', 'polyline', 'polygon', 'path', 'ellipse', 'foreignObject'].include(nodeName)) {
-        return document.createElementNS("http://www.w3.org/2000/svg", nodeName);
+	return document.createElementNS("http://www.w3.org/2000/svg", nodeName);
     }
 
     return document.createElement(nodeName);
@@ -95,7 +95,7 @@ let objectsPrefix = 'math_object_', objectsCount = 0, objects = {};
 
 function translateDOMElement(element, svg) {
     if (element.nodeType === 3) {
-        return document.createTextNode(element.nodeValue);
+	return document.createTextNode(element.nodeValue);
     }
 
     const nodeName = element.nodeName;
@@ -103,156 +103,156 @@ function translateDOMElement(element, svg) {
     let dom = null;
 
     if (nodeName !== 'meshgradient' && nodeName !== 'graphics3d') {
-        dom = createMathNode(element.nodeName);
+	dom = createMathNode(element.nodeName);
 
-        for (let i = 0; i < element.attributes.length; i++) {
-            const attr = element.attributes[i];
+	for (let i = 0; i < element.attributes.length; i++) {
+	    const attr = element.attributes[i];
 
-            if (attr.nodeName != 'ox' && attr.nodeName != 'oy') {
-                dom.setAttribute(attr.nodeName, attr.nodeValue);
-            }
-        }
+	    if (attr.nodeName != 'ox' && attr.nodeName != 'oy') {
+		dom.setAttribute(attr.nodeName, attr.nodeValue);
+	    }
+	}
     }
 
     if (nodeName === 'foreignObject') {
-        dom.setAttribute('width', svg.getAttribute('width'));
-        dom.setAttribute('height', svg.getAttribute('height'));
-        dom.setAttribute('style', dom.getAttribute('style') + '; text-align: left; padding-left: 2px; padding-right: 2px;');
+	dom.setAttribute('width', svg.getAttribute('width'));
+	dom.setAttribute('height', svg.getAttribute('height'));
+	dom.setAttribute('style', dom.getAttribute('style') + '; text-align: left; padding-left: 2px; padding-right: 2px;');
 
-        dom.setAttribute('ox', parseFloat(element.getAttribute('ox')));
-        dom.setAttribute('oy', parseFloat(element.getAttribute('oy')));
+	dom.setAttribute('ox', parseFloat(element.getAttribute('ox')));
+	dom.setAttribute('oy', parseFloat(element.getAttribute('oy')));
     }
 
     if (nodeName === 'mo') {
-        const op = element.firstChild.nodeValue;
+	const op = element.firstChild.nodeValue;
 
-        if (op === '[' ||
-            op === ']' ||
-            op === '{' ||
-            op === '}' ||
-            op === String.fromCharCode(12314) ||
-            op === String.fromCharCode(12315)
-           ) {
-            dom.setAttribute('maxsize', '3');
-        }
+	if (op === '[' ||
+	    op === ']' ||
+	    op === '{' ||
+	    op === '}' ||
+	    op === String.fromCharCode(12314) ||
+	    op === String.fromCharCode(12315)
+	   ) {
+	    dom.setAttribute('maxsize', '3');
+	}
     }
 
     let object = null;
 
     if (nodeName === 'graphics3d') {
-        const data = JSON.parse(element.getAttribute('data')),
-              div = document.createElement('div');
+	const data = JSON.parse(element.getAttribute('data')),
+	      div = document.createElement('div');
 
-        drawGraphics3d(div, data);
+	drawGraphics3d(div, data);
 
-        dom = div;
+	dom = div;
     }
 
     if (nodeName === 'svg' || nodeName === 'graphics3d' || nodeName.toLowerCase() === 'img') {
-        // create <mspace> that will contain the graphics
-        object = createMathNode('mspace');
+	// create <mspace> that will contain the graphics
+	object = createMathNode('mspace');
 
-        let width, height;
+	let width, height;
 
-        if (nodeName === 'svg' || nodeName.toLowerCase() === 'img') {
-            width = dom.getAttribute('width');
-            height = dom.getAttribute('height');
+	if (nodeName === 'svg' || nodeName.toLowerCase() === 'img') {
+	    width = dom.getAttribute('width');
+	    height = dom.getAttribute('height');
 
-            if (!width.endsWith('px')) {
-                width += 'px';
-            }
+	    if (!width.endsWith('px')) {
+		width += 'px';
+	    }
 
-            if (!height.endsWith('px')) {
-                height += 'px';
-            }
-        } else {
-            // TODO: calculate appropriate height and recalculate on every view change
-            width = height = '400px';
-        }
+	    if (!height.endsWith('px')) {
+		height += 'px';
+	    }
+	} else {
+	    // TODO: calculate appropriate height and recalculate on every view change
+	    width = height = '400px';
+	}
 
-        object.setAttribute('width', width);
-        object.setAttribute('height', height);
+	object.setAttribute('width', width);
+	object.setAttribute('height', height);
     }
 
     if (nodeName === 'svg') {
-        svg = dom;
+	svg = dom;
     }
 
     let rows = [[]];
 
     element.childNodes.forEach((child) => {
-        if (child.nodeName == 'mspace' && child.getAttribute('linebreak') == 'newline') {
-            rows.push([]);
-        } else {
-            rows[rows.length - 1].push(child);
-        }
+	if (child.nodeName == 'mspace' && child.getAttribute('linebreak') == 'newline') {
+	    rows.push([]);
+	} else {
+	    rows[rows.length - 1].push(child);
+	}
     });
 
     let childParent = dom;
 
     if (nodeName === 'math') {
-        const mstyle = createMathNode('mstyle');
-        mstyle.setAttribute('displaystyle', 'true');
+	const mstyle = createMathNode('mstyle');
+	mstyle.setAttribute('displaystyle', 'true');
 
-        dom.appendChild(mstyle);
+	dom.appendChild(mstyle);
 
-        childParent = mstyle;
+	childParent = mstyle;
     }
 
     if (rows.length > 1) {
-        const nospace = 'cell-spacing: 0; cell-padding: 0; row-spacing: 0; row-padding: 0; border-spacing: 0; padding: 0; margin: 0';
+	const nospace = 'cell-spacing: 0; cell-padding: 0; row-spacing: 0; row-padding: 0; border-spacing: 0; padding: 0; margin: 0';
 
-        const mtable = createMathNode('mtable');
-        mtable.setAttribute('rowspacing', '0');
-        mtable.setAttribute('columnalign', 'left');
-        mtable.setAttribute('style', nospace);
+	const mtable = createMathNode('mtable');
+	mtable.setAttribute('rowspacing', '0');
+	mtable.setAttribute('columnalign', 'left');
+	mtable.setAttribute('style', nospace);
 
-        rows.forEach((row) => {
-            const mtr = createMathNode('mtr'),
-                  mtd = createMathNode('mtd');
+	rows.forEach((row) => {
+	    const mtr = createMathNode('mtr'),
+		  mtd = createMathNode('mtd');
 
-            mtr.setAttribute('style', nospace);
-            mtd.setAttribute('style', nospace);
+	    mtr.setAttribute('style', nospace);
+	    mtd.setAttribute('style', nospace);
 
-            row.forEach((element) => {
-                const elmt = translateDOMElement(element, svg);
+	    row.forEach((element) => {
+		const elmt = translateDOMElement(element, svg);
 
-                if (nodeName == 'mtext') {
-                    // wrap element in mtext
-                    const outer = createMathNode('mtext');
-                    outer.appendChild(elmt);
+		if (nodeName == 'mtext') {
+		    // wrap element in mtext
+		    const outer = createMathNode('mtext');
+		    outer.appendChild(elmt);
 
-                    elmt = outer;
-                }
+		    elmt = outer;
+		}
 
-                mtd.appendChild(elmt);
-            });
+		mtd.appendChild(elmt);
+	    });
 
-            mtr.appendChild(mtd);
-            mtable.appendChild(mtr);
-        });
+	    mtr.appendChild(mtd);
+	    mtable.appendChild(mtr);
+	});
 
-        if (nodeName === 'mtext') {
-            // no mtable inside mtext, but mtable instead of mtext
-            dom = mtable;
-        } else {
-            childParent.appendChild(mtable);
-        }
+	if (nodeName === 'mtext') {
+	    // no mtable inside mtext, but mtable instead of mtext
+	    dom = mtable;
+	} else {
+	    childParent.appendChild(mtable);
+	}
     } else {
-        rows[0].forEach(
-            (element) => childParent.appendChild(
-                translateDOMElement(element, svg)
-            )
-        );
+	rows[0].forEach(
+	    (element) => childParent.appendChild(
+		translateDOMElement(element, svg)
+	    )
+	);
     }
 
     if (object) {
-        const id = objectsCount++;
+	const id = objectsCount++;
 
-        object.setAttribute('id', objectsPrefix + id);
-        objects[id] = dom;
+	object.setAttribute('id', objectsPrefix + id);
+	objects[id] = dom;
 
-        return object;
+	return object;
     }
 
     return dom;
@@ -263,39 +263,39 @@ function createLine(value) {
     container.innerHTML = value;
 
     if (container?.firstElementChild?.tagName === 'math') {
-        return translateDOMElement(container.firstChild);
+	return translateDOMElement(container.firstChild);
     } else if (container?.firstElementChild?.tagName === 'GRAPHICS3D') {
-        const div = document.createElement('div');
+	const div = document.createElement('div');
 
-        drawGraphics3d(div, JSON.parse(container.firstElementChild.attributes.data.value));
+	drawGraphics3d(div, JSON.parse(container.firstElementChild.attributes.data.value));
 
-        div.style.overflow = 'hidden';
-        div.style.position = 'relative';
-        div.style.margin = 'auto';
+	div.style.overflow = 'hidden';
+	div.style.position = 'relative';
+	div.style.margin = 'auto';
 
-        return div;
+	return div;
     } else if (container?.firstElementChild?.tagName === 'svg') {
-        container.firstElementChild.style.display = 'block';
-        container.firstElementChild.style.width = '100%';
-        container.firstElementChild.style.maxWidth = '400px';
-        container.firstElementChild.style.margin = 'auto';
+	container.firstElementChild.style.display = 'block';
+	container.firstElementChild.style.width = '100%';
+	container.firstElementChild.style.maxWidth = '400px';
+	container.firstElementChild.style.margin = 'auto';
 
-        return container;
+	return container;
     } else {
-        const lines = container.innerHTML.split('\n');
+	const lines = container.innerHTML.split('\n');
 
-        const p = document.createElement('p');
-        p.className = 'string';
+	const p = document.createElement('p');
+	p.className = 'string';
 
-        for (let i = 0; i < lines.length; i++) {
-            p.innerText += prepareText(lines[i]);
+	for (let i = 0; i < lines.length; i++) {
+	    p.innerText += prepareText(lines[i]);
 
-            if (i < lines.length - 1) {
-                p.appendChild(document.createElement('br'));
-            }
-        }
+	    if (i < lines.length - 1) {
+		p.appendChild(document.createElement('br'));
+	    }
+	}
 
-        return p;
+	return p;
     }
 }
 
@@ -305,48 +305,48 @@ function afterProcessResult(list, command) {
 
     MathJax.Hub.Queue([command, MathJax.Hub, list]);
     MathJax.Hub.Queue(() => {
-        // inject SVG and other non-MathML objects into corresponding <mspace>s
-        list.querySelectorAll('.mspace').forEach((mspace) => {
-            const id = mspace.getAttribute('id').substr(objectsPrefix.length);
+	// inject SVG and other non-MathML objects into corresponding <mspace>s
+	list.querySelectorAll('.mspace').forEach((mspace) => {
+	    const id = mspace.getAttribute('id').substr(objectsPrefix.length);
 
-            mspace.appendChild(objects[id]);
-        });
+	    mspace.appendChild(objects[id]);
+	});
     });
 
     if (!MathJax.Hub.Browser.isOpera) {
-        // Opera 11.01 Build 1190 on Mac OS X 10.5.8 crashes on this call for Plot[x,{x,0,1}]
-        // => leave inner MathML untouched
-        MathJax.Hub.Queue(['Typeset', MathJax.Hub, list]);
+	// Opera 11.01 Build 1190 on Mac OS X 10.5.8 crashes on this call for Plot[x,{x,0,1}]
+	// => leave inner MathML untouched
+	MathJax.Hub.Queue(['Typeset', MathJax.Hub, list]);
     }
 
     MathJax.Hub.Queue(() => {
-        list.querySelectorAll('foreignObject > span > nobr > span.math')
-            .forEach((math) => {
-                const content = math.firstChild.firstChild.firstChild;
+	list.querySelectorAll('foreignObject > span > nobr > span.math')
+	    .forEach((math) => {
+		const content = math.firstChild.firstChild.firstChild;
 
-                math.removeChild(math.firstChild);
-                math.insertBefore(content, math.firstChild);
+		math.removeChild(math.firstChild);
+		math.insertBefore(content, math.firstChild);
 
-                if (command === 'Typeset') {
-                    // recalculate positions of insets based on ox/oy properties
-                    const foreignObject = math.parentNode.parentNode.parentNode,
-                          dimensions = math.getDimensions();
+		if (command === 'Typeset') {
+		    // recalculate positions of insets based on ox/oy properties
+		    const foreignObject = math.parentNode.parentNode.parentNode,
+			  dimensions = math.getDimensions();
 
-                    const ox = parseFloat(foreignObject.getAttribute('ox')),
-                          oy = parseFloat(foreignObject.getAttribute('oy')),
-                          width = dimensions.width + 4,
-                          height = dimensions.height + 4;
+		    const ox = parseFloat(foreignObject.getAttribute('ox')),
+			  oy = parseFloat(foreignObject.getAttribute('oy')),
+			  width = dimensions.width + 4,
+			  height = dimensions.height + 4;
 
-                    let x = parseFloat(foreignObject.getAttribute('x').substr()),
-                        y = parseFloat(foreignObject.getAttribute('y'));
+		    let x = parseFloat(foreignObject.getAttribute('x').substr()),
+			y = parseFloat(foreignObject.getAttribute('y'));
 
-                    x = x - width / 2.0 - ox * width / 2.0;
-                    y = y - height / 2.0 + oy * height / 2.0;
+		    x = x - width / 2.0 - ox * width / 2.0;
+		    y = y - height / 2.0 + oy * height / 2.0;
 
-                    foreignObject.setAttribute('x', x + 'px');
-                    foreignObject.setAttribute('y', y + 'px');
-                }
-            });
+		    foreignObject.setAttribute('x', x + 'px');
+		    foreignObject.setAttribute('y', y + 'px');
+		}
+	    });
     });
 }
 
@@ -361,133 +361,152 @@ function setResult(list, results) {
     const li = document.createElement('li');
     li.className = 'out';
 
-    if (results.length == 1 && results[0].form == "SyntaxError") {
-        const result = results[0];
-        const out = result.out[0];
+    if (results.length == 1 && results[0].form == "Syntax Error") {
+	const result = results[0];
+	const out = result.out[0];
 
 	// Syntax Error prefix or code
-        const bold = document.createElement('b');
-        bold.className = "message"
-        bold.innerHTML = out.prefix + ":"
-        resultList.appendChild(bold)
+	const bold = document.createElement('b');
+	bold.className = "message"
+	bold.innerHTML = out.prefix + ":"
+	resultList.appendChild(bold);
 
 
 	// Syntax Error message
-        const pre = document.createElement('pre');
-        pre.innerHTML = out.text
+	const pre = document.createElement('pre');
+	pre.innerHTML = out.text;
 
 	// Add this to a list element in a block (which is CSS styled with a nice
 	// frame around it.
-        resultList.appendChild(pre)
-        resultList.style.display = 'block';
-        li.appendChild(resultList);
-        list.appendChild(li);
+	resultList.appendChild(pre);
+	resultList.style.display = 'block';
+	li.appendChild(resultList);
+	list.appendChild(li);
+    } else if (results.length == 1 && results[0].form == "Python Exception") {
+	const result = results[0];
+	const out = result.out[0];
 
+	// Traceback header
+	const bold = document.createElement('b');
+	bold.className = "message";
+	bold.innerHTML = out.prefix + ":" + out.text[0]
+	resultList.appendChild(bold);
+
+	// Traceback lines. Start at index 1.
+
+	// FIXME: redo with better formatting, (a table?) with parsed entries.
+	const pre = document.createElement('pre');
+	// Last line repeats information from the first line?
+	pre.innerHTML = out.text.slice(1, -1).join();
+
+	resultList.appendChild(pre);
+	resultList.style.display = 'block';
+	li.appendChild(resultList);
+	list.appendChild(li);
     } else {
-        results.forEach((result) => {
+	results.forEach((result) => {
 
-            result.out.forEach((out) => {
-                const li = document.createElement('li');
-                li.className = out.message ? 'message' : 'print';
+	    result.out.forEach((out) => {
+		const li = document.createElement('li');
+		li.className = out.message ? 'message' : 'print';
 
-                if (out.message) {
-                    li.innerHTML += out.prefix + ': ';
-                }
+		if (out.message) {
+		    li.innerHTML += out.prefix + ': ';
+		}
 
-                li.appendChild(createLine(out.text));
+		li.appendChild(createLine(out.text));
 
-                resultList.appendChild(li);
-            });
+		resultList.appendChild(li);
+	    });
 
-            if (result.result) {
-                const li = document.createElement('li');
-                li.className = 'result';
-                li.appendChild(createLine(result.result));
+	    if (result.result) {
+		const li = document.createElement('li');
+		li.className = 'result';
+		li.appendChild(createLine(result.result));
 
-                resultList.appendChild(li);
-                resultList.style.display = 'block';
-            }
+		resultList.appendChild(li);
+		resultList.style.display = 'block';
+	    }
 
-            if (result.out.length) {
-                resultList.style.display = 'block';
-            }
-        });
-
+	    if (result.out.length) {
+		resultList.style.display = 'block';
+	    }
+	});
 
 	// Add this to a list element in a block (which is CSS styled with a nice
 	// frame around it.
-        li.appendChild(resultList);
-        list.appendChild(li);
+	li.appendChild(resultList);
+	list.appendChild(li);
 
-	// rocky: I think this is gross that we post-process the list. But so be it.
-        afterProcessResult(list);
+	// rocky: I think this is gross that we post-process the list. But, for now, so be it.
+	afterProcessResult(list);
     }
 }
 
 function submitQuery(element, onfinish, query) {
     if (welcome) {
-        document.getElementById('welcomeContainer')?.fade({ duration: 0.2 });
+	document.getElementById('welcomeContainer')?.fade({ duration: 0.2 });
 
-        if (document.getElementById('hideStartupMsg')?.checked) {
-            localStorage.setItem('hideMathicsStartupMsg', 'true');
-        }
+	if (document.getElementById('hideStartupMsg')?.checked) {
+	    localStorage.setItem('hideMathicsStartupMsg', 'true');
+	}
 
-        welcome = false;
-        document.getElementById('logo').classList.remove('load');
+	welcome = false;
+	document.getElementById('logo').classList.remove('load');
     }
 
     element.li?.classList.add('loading');
     document.getElementById('logo')?.classList.add('working');
 
     new Ajax.Request('/ajax/query/', {
-        method: 'post',
-        parameters: { query: query || element.value },
-        onSuccess: (transport) => {
-            if (element.ul) {
-                element.ul.select('li[class!=request][class!=submitbutton]')
-                    .forEach((element) => element.remove());
+	method: 'post',
+	parameters: { query: query || element.value },
+	onSuccess: (transport) => {
+	    if (element.ul) {
+		element.ul.select('li[class!=request][class!=submitbutton]')
+		    .forEach((element) => element.remove());
 
-                if (!transport.responseText) {
-                    // a fatal Python error has occurred, e.g. on 4.4329408320439^43214234345
-                    // ("Fatal Python error: mp_reallocate failure")
-                    // -> print overflow message
-                    transport.responseText = '{"results": [{"out": [{"prefix": "General::noserver", "message": true, "tag": "noserver", "symbol": "General", "text": "<math><mrow><mtext>No server running.</mtext></mrow></math>"}]}]}';
-                }
+		if (!transport.responseText) {
+		    // a fatal Python error has occurred, e.g. on 4.4329408320439^43214234345
+		    // ("Fatal Python error: mp_reallocate failure")
+		    // -> print overflow message
+		    transport.responseText = '{"results": [{"out": [{"prefix": "General::noserver", "message": true, "tag": "noserver", "symbol": "General", "text": "<math><mrow><mtext>No server running.</mtext></mrow></math>"}]}]}';
+		}
 
-                const response = JSON.parse(transport.responseText);
+		const response = JSON.parse(transport.responseText);
 
-                setResult(element.ul, response.results);
-                element.submitted = true;
-                element.results = response.results;
+		setResult(element.ul, response.results);
+		element.submitted = true;
+		element.results = response.results;
 
-                const next = element.li.nextSibling;
+		const next = element.li.nextSibling;
 
-                if (next) {
-                    next.textarea.focus();
-                } else {
-                    createQuery();
-                }
-            }
-        },
-        onFailure: () => {
-            element?.ul.select('li[class!=request]')
-                .forEach((element) => element.remove());
+		if (next) {
+		    next.textarea.focus();
+		} else {
+		    createQuery();
+		}
+	    }
+	},
+	onFailure: () => {
+	    element?.ul.select('li[class!=request]')
+		.forEach((element) => element.remove());
 
-            const li = document.createElement('li');
-            li.className = 'serverError';
-            li.innerText = 'Sorry, an error occurred while processing your request!';
+	    const li = document.createElement('li');
+	    li.className = 'serverError';
+	    li.innerText = 'Sorry, an error occurred while processing your request!';
 
-            element?.ul.appendChild(li);
-            element.submitted = true;
-        },
-        onComplete: () => {
-            element?.li.classList.remove('loading');
-            document.getElementById('logo')?.classList.remove('working');
+	    element?.ul.appendChild(li);
+	    element.submitted = true;
+	},
+	onComplete: () => {
+	    element?.li.classList.remove('loading');
+	    document.getElementById('logo')?.classList.remove('working');
 
-            if (onfinish) {
-                onfinish();
-            }
-        }
+	    if (onfinish) {
+		onfinish();
+	    }
+	}
     });
 }
 
@@ -495,65 +514,65 @@ function keyDown(event) {
     const textArea = lastFocus;
 
     if (!textArea) {
-        return;
+	return;
     }
 
     refreshInputSize(textArea);
 
     if (event.key === 'Enter' && (event.shiftKey || event.location === 3)) {
-        event.stop();
+	event.stop();
 
-        if (textArea.value.strip()) {
-            submitQuery(textArea);
-        }
+	if (textArea.value.strip()) {
+	    submitQuery(textArea);
+	}
     } else if (event.key === 'ArrowUp') {
-        if (textArea.selectionStart === 0 && textArea.selectionEnd === 0) {
-            if (isEmpty(textArea)) {
-                if (textArea.li.previousSibling) {
-                    textArea.li.previousSibling.textarea.focus();
-                }
-            } else {
-                createQuery(textArea.li);
-            }
-        }
+	if (textArea.selectionStart === 0 && textArea.selectionEnd === 0) {
+	    if (isEmpty(textArea)) {
+		if (textArea.li.previousSibling) {
+		    textArea.li.previousSibling.textarea.focus();
+		}
+	    } else {
+		createQuery(textArea.li);
+	    }
+	}
     } else if (event.key === 'ArrowDown') {
-        if (textArea.selectionStart === textArea.value.length && textArea.selectionEnd === textArea.selectionStart) {
-            if (isEmpty(textArea)) {
-                if (textArea.li.nextSibling) {
-                    textArea.li.nextSibling.textarea.focus();
-                }
-            } else {
-                createQuery(textArea.li.nextSibling);
-            }
-        }
+	if (textArea.selectionStart === textArea.value.length && textArea.selectionEnd === textArea.selectionStart) {
+	    if (isEmpty(textArea)) {
+		if (textArea.li.nextSibling) {
+		    textArea.li.nextSibling.textarea.focus();
+		}
+	    } else {
+		createQuery(textArea.li.nextSibling);
+	    }
+	}
     } else if (isGlobalKey(event)) {
-        event.stop();
-        event.stopPropagation();
-        event.preventDefault();
+	event.stop();
+	event.stopPropagation();
+	event.preventDefault();
     }
 }
 
 function deleteMouseDown(event) {
     if (event.isLeftClick()) {
-        deleting = true;
+	deleting = true;
     }
 }
 
 function deleteClick() {
     if (lastFocus === this.li.textarea) {
-        lastFocus = null;
+	lastFocus = null;
     }
 
     this.li.remove();
     deleting = false;
 
     if (blurredElement) {
-        blurredElement.focus();
-        blurredElement = null;
+	blurredElement.focus();
+	blurredElement = null;
     }
 
     if (document.getElementById('queries').childElementCount === 0) {
-        createQuery();
+	createQuery();
     }
 }
 
@@ -564,9 +583,9 @@ function moveMouseDown() {
 
 function moveMouseUp() {
     if (movedItem) {
-        movedItem.classList.remove('moving');
-        movedItem.textarea.focus();
-        movedItem = null;
+	movedItem.classList.remove('moving');
+	movedItem.textarea.focus();
+	movedItem = null;
     }
 }
 
@@ -579,17 +598,17 @@ function onBlur() {
     blurredElement = this;
 
     if (!deleting &&
-        this.li != movedItem &&
-        isEmpty(this) &&
-        document.getElementById('queries').childElementCount > 1
+	this.li != movedItem &&
+	isEmpty(this) &&
+	document.getElementById('queries').childElementCount > 1
        ) {
-        this.li.display = 'none';
+	this.li.display = 'none';
 
-        if (this == lastFocus) {
-            lastFocus = null;
-        }
+	if (this == lastFocus) {
+	    lastFocus = null;
+	}
 
-        this.li.remove();
+	this.li.remove();
     }
 
     this.li.classList.remove('focused');
@@ -598,9 +617,9 @@ function onBlur() {
 function createSortable() {
     Position.includeScrollOffsets = true;
     Sortable.create('queries', {
-        handle: 'move',
-        scroll: 'document',
-        scrollSensitivity: 1 // otherwise strange flying-away of item at top
+	handle: 'move',
+	scroll: 'document',
+	scrollSensitivity: 1 // otherwise strange flying-away of item at top
     });
 }
 
@@ -654,13 +673,13 @@ function createQuery(beforeElement, noFocus, updatingAll) {
     const queries = document.getElementById('queries');
 
     if (beforeElement) {
-        queries.insertBefore(li, beforeElement);
+	queries.insertBefore(li, beforeElement);
     } else {
-        queries.appendChild(li);
+	queries.appendChild(li);
     }
 
     if (!updatingAll) {
-        refreshInputSize(textarea);
+	refreshInputSize(textarea);
     }
 
     textarea.addEventListener('keyup', inputChange);
@@ -672,19 +691,19 @@ function createQuery(beforeElement, noFocus, updatingAll) {
     moveHandle.addEventListener('mousedown', moveMouseDown);
     document.addEventListener('mouseup', moveMouseUp);
     submitButton.addEventListener('mousedown', () => {
-        if (textarea.value.strip()) {
-            submitQuery(textarea);
-        } else {
-            textarea.focus();
-        }
+	if (textarea.value.strip()) {
+	    submitQuery(textarea);
+	} else {
+	    textarea.focus();
+	}
     });
 
     if (!updatingAll) {
-        createSortable();
+	createSortable();
     }
 
     if (!noFocus) {
-        textarea.focus();
+	textarea.focus();
     }
 
     return li;
@@ -692,14 +711,14 @@ function createQuery(beforeElement, noFocus, updatingAll) {
 
 function documentMouseDown(event) {
     if (event.isLeftClick()) {
-        if (clickedQuery) {
-            clickedQuery = null;
-            mouseDownEvent = null;
+	if (clickedQuery) {
+	    clickedQuery = null;
+	    mouseDownEvent = null;
 
-            return;
-        }
+	    return;
+	}
 
-        mouseDownEvent = event;
+	mouseDownEvent = event;
     }
 }
 
@@ -711,13 +730,13 @@ function documentClick(event) {
     event = mouseDownEvent;
 
     if (!event) {
-        return;
+	return;
     }
 
     if (queries.childElementCount === 1 && isEmpty(queries.firstElementChild.textarea)) {
-        queries.firstElementChild.textarea.focus();
+	queries.firstElementChild.textarea.focus();
 
-        return;
+	return;
     }
 
     const documentElement = document.getElementById('document');
@@ -726,12 +745,12 @@ function documentClick(event) {
     let element = null;
 
     for (let i = 0; i < queries.childElementCount; i++) {
-        // margin-top: 10px
-        if (queries.children[i].positionedOffset().top + 20 > y) {
-            element = queries.children[i];
+	// margin-top: 10px
+	if (queries.children[i].positionedOffset().top + 20 > y) {
+	    element = queries.children[i];
 
-            break;
-        }
+	    break;
+	}
     }
 
     createQuery(element);
@@ -743,19 +762,19 @@ function queryMouseDown() {
 
 function focusLast() {
     if (lastFocus) {
-        lastFocus.focus();
+	lastFocus.focus();
     } else {
-        createQuery();
+	createQuery();
     }
 }
 
 function isGlobalKey(event) {
     if (event.ctrlKey) {
-        const key = event.key.toLowerCase();
+	const key = event.key.toLowerCase();
 
-        if (key === 'd' || key === 's' || key === 'o') {
-            return true;
-        }
+	if (key === 'd' || key === 's' || key === 'o') {
+	    return true;
+	}
     }
 
     return false;
@@ -763,83 +782,83 @@ function isGlobalKey(event) {
 
 function globalKeyUp(event) {
     if (!popup && event.ctrlKey) {
-        switch (event.keyCode) {
-        case 68: // D
-            showDoc();
-            document.getElementById('search').select();
-            event.stop();
+	switch (event.keyCode) {
+	case 68: // D
+	    showDoc();
+	    document.getElementById('search').select();
+	    event.stop();
 
-            break;
-        // case 67: // C
-        //      focusLast();
-        //      event.stop();
-        //
-        //      break;
-        case 83: // S
-            event.stop();
-            event.stopPropagation();
-            event.preventDefault();
-            showSave();
+	    break;
+	// case 67: // C
+	//	focusLast();
+	//	event.stop();
+	//
+	//	break;
+	case 83: // S
+	    event.stop();
+	    event.stopPropagation();
+	    event.preventDefault();
+	    showSave();
 
-            break;
-        case 79: // O
-            event.stop();
-            event.stopPropagation();
-            event.preventDefault();
-            showOpen();
+	    break;
+	case 79: // O
+	    event.stop();
+	    event.stopPropagation();
+	    event.preventDefault();
+	    showOpen();
 
-            break;
-        }
+	    break;
+	}
     }
 }
 
 function domLoaded() {
     MathJax.Hub.Config({
-        'HTML-CSS': {
-            imageFont: null,
-            linebreaks: {
-                automatic: true,
-                width: '70% container'
-            }
-        },
-        MMLorHTML: {
-            // the output jax that is to be preferred when both are possible
-            // (set to 'MML' for native MathML, 'HTML' for MathJax's HTML-CSS output jax).
-            prefer: {
-                MSIE: 'HTML',
-                Firefox: 'HTML',
-                Opera: 'HTML',
-                other: 'HTML'
-            }
-        }
+	'HTML-CSS': {
+	    imageFont: null,
+	    linebreaks: {
+		automatic: true,
+		width: '70% container'
+	    }
+	},
+	MMLorHTML: {
+	    // the output jax that is to be preferred when both are possible
+	    // (set to 'MML' for native MathML, 'HTML' for MathJax's HTML-CSS output jax).
+	    prefer: {
+		MSIE: 'HTML',
+		Firefox: 'HTML',
+		Opera: 'HTML',
+		other: 'HTML'
+	    }
+	}
     });
 
     MathJax.Hub.Configured();
 
     if (localStorage.getItem('hideMathicsStartupMsg') === 'true') {
-        document.getElementById('welcome').style.display = 'none';
+	document.getElementById('welcome').style.display = 'none';
     }
 
     const queriesContainer = document.getElementById('queriesContainer');
 
     if (queriesContainer) {
-        const queries = document.createElement('ul'),
-              documentElement = document.getElementById('document');
+	const queries = document.createElement('ul'),
+	      documentElement = document.getElementById('document');
 
-        queries.id = 'queries';
+	queries.id = 'queries';
 
-        queriesContainer.appendChild(queries);
+	queriesContainer.appendChild(queries);
 
-        documentElement.addEventListener('mousedown', documentMouseDown);
-        documentElement.addEventListener('click', documentClick);
+	documentElement.addEventListener('mousedown', documentMouseDown);
+	documentElement.addEventListener('click', documentClick);
 
-        document.addEventListener('keydown', keyDown);
-        window.addEventListener('keydown', globalKeyUp);
-        window.addEventListener('keyup', globalKeyUp);
+	document.addEventListener('keydown', keyDown);
+	window.addEventListener('keydown', globalKeyUp);
+	window.addEventListener('keyup', globalKeyUp);
 
-        if (!loadLink()) {
-            createQuery();
-        }
+	if (!loadLink()) {
+	    createQuery();
+	}
     }
 }
 
@@ -848,15 +867,15 @@ window.addEventListener('resize', refreshInputSizes);
 
 window.addEventListener('resize', function () {
     if (timeout >= 0) {
-        // the user is still resizing so postpone the action further
-        window.clearTimeout(timeout);
+	// the user is still resizing so postpone the action further
+	window.clearTimeout(timeout);
     }
 
     timeout = window.setTimeout(function () {
-        document.querySelectorAll('#queries ul').forEach((ul) => {
-            afterProcessResult(ul, 'Rerender');
-        });
+	document.querySelectorAll('#queries ul').forEach((ul) => {
+	    afterProcessResult(ul, 'Rerender');
+	});
 
-        timeout = -1; // reset the timeout
+	timeout = -1; // reset the timeout
     }, 500);
 });

--- a/mathics_django/web/views.py
+++ b/mathics_django/web/views.py
@@ -272,7 +272,7 @@ def query(request: WSGIRequest) -> JsonResponse:
                 source_code,
                 messages,
             ) = evaluation.parse_feeder_returning_code_and_messages(feeder)
-            if expr is None or len(messages) > 0 and messages[0].tag in ["sntxf"]:
+            if len(messages) > 0 and messages[0].tag in ("sntxf", "sntxb", "sntxi"):
                 # Syntax or Parse errors.
 
                 # For simplicity, when there is an error there will be just one
@@ -282,6 +282,7 @@ def query(request: WSGIRequest) -> JsonResponse:
 
                 # Strip quotes from messages.
                 message = evaluation.out[0]
+
                 if message.text.startswith('"') and message.text.endswith('"'):
                     message.text = message.text[1:-1]
                 results.append(
@@ -290,11 +291,17 @@ def query(request: WSGIRequest) -> JsonResponse:
                         result=None,
                         line_no=None,
                         last_eval=None,
-                        form="SyntaxError",
+                        form="Syntax Error",
                     )
                 )
                 evaluation.out = []
                 continue
+            elif expr is None:
+                # Most likely comment.
+                # TODO: source_code should have '(* ... *)' and
+                # better would be to create tagged result.
+                continue
+
             result = evaluation.evaluate(expr, timeout=TIMEOUT)
             results.append(result)
 
@@ -307,18 +314,30 @@ def query(request: WSGIRequest) -> JsonResponse:
         evaluation.definitions = definitions
     except Exception as exc:
         if settings.DEBUG and settings.DISPLAY_EXCEPTIONS:
-            info = traceback.format_exception(*sys.exc_info())
-            info = "\n".join(info)
-            msg = "Exception raised: %s\n\n%s" % (exc, info)
-            results.append(Result([Message("System", "exception", msg)], None, None))
+            call_stack = traceback.format_exception(*sys.exc_info())
+            except_head = f"Exception raised: {exc}"
+            message = Message(
+                "Python Exception", tag="exception", text=[except_head] + call_stack
+            )
+            results.append(
+                Result(
+                    out=[message],
+                    result=None,
+                    line_no=None,
+                    last_eval=None,
+                    form="Python Exception",
+                )
+            )
         else:
             raise
     result = {
         "results": [result.get_data() for result in results],
     }
     if settings.LOG_ON_CONSOLE:
+        from pprint import pprint as pp
+
         print(evaluation.timeout)
-        print(str(result))
+        pp(result)
         # query_log.timeout = evaluation.timeout
         # query_log.result = str(result)  # evaluation.results
         # query_log.error = False


### PR DESCRIPTION
Better handling and formatting of Syntax Errors and Python Exceptions.

views.py:
-------------
    
We now use the "form" parameter to detect syntax errors and to mark exception errors that are to be displayed.
    
This requires a recent Mathics 6.0.0
    
mathics.js:
---------------
    
Uses the tag set up for it in `views.py` to it to detect "Syntax Error" and "Python Exception" and formats these in a custom way that better displays these.
    
More work could be done for Python Exception in the area of custom traceback rendering. For example, file paths could be incorporated in link (<a>) tags.
    
Reformatted the file to remove tabbing and to make explicit (for Emacs) indent of 4 spaces.
