### PR TITLE
More traceback tweaking...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ runserver: $(THREEJS)
 
 #: Run Django-based server in development mode. Use environment variable "o" for manage options
 runserver-debug: $(THREEJS)
-	MATHICS_DJANGO_LOG_ON_CONSOLE=true $(PYTHON) mathics_django/manage.py runserver $o
+	MATHICS_DJANGO_DISPLAY_EXCEPTIONS=true MATHICS_DJANGO_LOG_ON_CONSOLE=true $(PYTHON) mathics_django/manage.py runserver $o
 
 #: Remove ChangeLog
 rmChangeLog:

--- a/mathics_django/web/media/js/mathics.js
+++ b/mathics_django/web/media/js/mathics.js
@@ -397,7 +397,7 @@ function setResult(list, results) {
 	// FIXME: redo with better formatting, (a table?) with parsed entries.
 	const pre = document.createElement('pre');
 	// Last line repeats information from the first line?
-	pre.innerHTML = out.text.slice(1, -1).join();
+	pre.innerHTML = out.text.slice(1, -1).join("\n");
 
 	resultList.appendChild(pre);
 	resultList.style.display = 'block';

--- a/mathics_django/web/views.py
+++ b/mathics_django/web/views.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import sys
 import traceback
 
 from django.core.handlers.wsgi import WSGIRequest
@@ -312,9 +311,19 @@ def query(request: WSGIRequest) -> JsonResponse:
             add_builtin=True, extension_modules=default_pymathics_modules
         )
         evaluation.definitions = definitions
+
     except Exception as exc:
+
+        # Should we show the Python exception details back to the user?
         if settings.DEBUG and settings.DISPLAY_EXCEPTIONS:
-            call_stack = traceback.format_exception(*sys.exc_info())
+            call_stack = traceback.format_exception(exc)
+            # TODO: we may want to do other processing on the traceback
+            #       like splitting up lines. Encapsulate the below and put
+            #       in a function.
+            # FIXME: allow the the stack limit to be user settable
+            if len(call_stack) > 18:
+                call_stack = call_stack[:9] + ["..."] + call_stack[-9:]
+
             except_head = f"Exception raised: {exc}"
             message = Message(
                 "Python Exception", tag="exception", text=[except_head] + call_stack


### PR DESCRIPTION
mathics.js: remove erroneous "," at beginning of lines due to .join();
            use .join("\n")
views.py: If we have a long traceback - over 19 lines, chop out the
            middle

Makefile: runserver-debug shows on console and shows traceback in web app