### PR TITLE
remove spaces and line breaks inside urls

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@ CHANGES
   - Python Implementation (CPython, PyPy, Pyston) explicitly is shown
   - Optional Python packages are also shown along with their version
 
+* In documentation, ``<url>...</url>`` admits now to be splitted in
+  several indented lines.
+
 5.0.0
 -----
 

--- a/mathics_django/doc/utils.py
+++ b/mathics_django/doc/utils.py
@@ -124,12 +124,12 @@ def escape_html(text, verbatim_mode=False, counters=None, single_line=False):
             content = match.group("content")
             #
             # Sometimes it happens that the URL does not
-            # fit in 80 characters. Then, to avoid that 
+            # fit in 80 characters. Then, to avoid that
             # flake8 complains, and also to have a
             # nice and readable ASCII representation,
             # we would like to split the URL in several,
             # lines, having indentation spaces.
-            # 
+            #
             # The following line removes these extra
             # characters, which would spoil the URL,
             # producing a single line, space-free string.

--- a/mathics_django/doc/utils.py
+++ b/mathics_django/doc/utils.py
@@ -122,6 +122,18 @@ def escape_html(text, verbatim_mode=False, counters=None, single_line=False):
         def repl_hypertext(match):
             tag = match.group("tag")
             content = match.group("content")
+            #
+            # Sometimes it happens that the URL does not
+            # fit in 80 characters. Then, to avoid that 
+            # flake8 complains, and also to have a
+            # nice and readable ASCII representation,
+            # we would like to split the URL in several,
+            # lines, having indentation spaces.
+            # 
+            # The following line removes these extra
+            # characters, which would spoil the URL,
+            # producing a single line, space-free string.
+            #
             content = content.replace(" ", "").replace("\n", "")
             if tag == "em":
                 return r"<em>%s</em>" % content

--- a/mathics_django/doc/utils.py
+++ b/mathics_django/doc/utils.py
@@ -122,6 +122,7 @@ def escape_html(text, verbatim_mode=False, counters=None, single_line=False):
         def repl_hypertext(match):
             tag = match.group("tag")
             content = match.group("content")
+            content = content.replace(" ", "").replace("\n", "")
             if tag == "em":
                 return r"<em>%s</em>" % content
             elif tag == "url":


### PR DESCRIPTION
This single line PR is a proposal about how to handle long urls in docstrings. With this patch

```
<url>:NetworkX:
     https://networkx.org/documentation/networkx-2.8.8/reference/algorithms/\
      generated/networkx.algorithms.tree.mst.minimum_spanning_edges.html
</url>
```

the <url></url> tag is processed as
```
<a href=https://networkx.org/documentation/networkx-2.8.8/reference/algorithms/generated/networkx.algorithms.tree.mst.minimum_spanning_edges.html>NetworkX</a>
```

The pros are 
* we do not need to have long lines in documentation (flake8 complains about it)
* in the code, we can preserve the indentation, and visually looks better.
* we do not need to change the docstrings that were written like this.

The contra is that I don't know if sphinx supports something like that, so it would make the migration harder.