### PR TITLE
Reinstate the failing Graph examples...

### DIFF
--- a/mathics_django/web/media/js/inout.js
+++ b/mathics_django/web/media/js/inout.js
@@ -367,11 +367,10 @@ Graphics3D[Table[Point[{x, y, z}], {x, 5}, {y, 5}, {z, 5}]]',
 	'LoadModule["pymathics.graph"]',
 	'BinomialTree[3, DirectedEdges->True]',
 	'BalancedTree[3, 3]',
-	/*
-         There may be a a contention for UndirectedEdge here by combinatorica.
-         'g = Graph[{1 -> 2, 2 -> 3, 3 <-> 4}, VertexLabels->True]',
-	'ConnectedComponents[g]',
-        */
+	'(* Note that we need to specify context Pymathics` below because combinatorica also defines Graph, ConnectedComponents, and WeaklyConnectedComponents  *)',
+        'g = Pymathics`Graph[{1 -> 2, 2 -> 3, 3 <-> 4}, VertexLabels->True]',
+	'Pymathics`ConnectedComponents[g]',
+	'Pymathics`WeaklyConnectedComponents[g]',
 	'(**** Mathics3 Natural Language Module - this may fail if your system does not have pymathics.natlang ****)',
 	'LoadModule["pymathics.natlang"]',
 	'Pluralize["try"]',


### PR DESCRIPTION
The problem is that combinatorica definitions and Mathics3 Graph define the same functions