### PR TITLE
adding background and tooltips to Graphics3D

### DIFF
--- a/mathics_django/web/media/js/mathics.js
+++ b/mathics_django/web/media/js/mathics.js
@@ -266,8 +266,12 @@ function createLine(value) {
         return translateDOMElement(container.firstChild);
     } else if (container?.firstElementChild?.tagName === 'GRAPHICS3D') {
         const div = document.createElement('div');
-
-        drawGraphics3d(div, JSON.parse(container.firstElementChild.attributes.data.value));
+	var json_data_value = JSON.parse(container.firstElementChild.attributes.data.value);
+	div.style.backgroundColor = json_data_value["background_color"];
+	if ("tooltip_text" in json_data_value){
+	    div.title = json_data_value["tooltip_text"];
+	}
+        drawGraphics3d(div, json_data_value);
 
         div.style.overflow = 'hidden';
         div.style.position = 'relative';


### PR DESCRIPTION
This PR restores the functionality of the `Background` option in Graphics3D, as well as provides the way to show a tooltip text in this kind of graphics object.

![imagen](https://github.com/Mathics3/mathics-django/assets/2862288/9336f364-034a-4b78-a890-222510a885af)
