### PR TITLE
Close matplotlib graph ...

### DIFF
--- a/mathics_django/web/format.py
+++ b/mathics_django/web/format.py
@@ -437,6 +437,10 @@ def format_graph(G) -> str:
     global node_size
     global cached_pair
 
+    # Make sure we close any previous graph before starting to create
+    # new graph.
+    pyplot.close()
+
     pyplot.switch_backend("AGG")
     cached_pair = None
 


### PR DESCRIPTION
before starting to format a new graph.

In matplotlib 3.9.1 this was causing graphs to get overlaid.