### PR TITLE
Handle multiline strings

### DIFF
--- a/mathics_django/web/media/css/styles.css
+++ b/mathics_django/web/media/css/styles.css
@@ -764,5 +764,5 @@ div.filelist table a:hover {
 
 p.string {
 	color: #a61515;
-	text-align: justify;
+	text-align: center;
 }

--- a/mathics_django/web/media/css/styles.css
+++ b/mathics_django/web/media/css/styles.css
@@ -764,5 +764,5 @@ div.filelist table a:hover {
 
 p.string {
 	color: #a61515;
-	text-align: center;
+	text-align: justify;
 }

--- a/mathics_django/web/media/js/mathics.js
+++ b/mathics_django/web/media/js/mathics.js
@@ -287,6 +287,9 @@ function createLine(value) {
         const lines = container.innerText.split('\n');
         const p = document.createElement('p');
         p.className = 'string';
+	if(lines.length>1){
+	    p.style.textAlign = 'justify';
+	}
 
         for (let i = 0; i < lines.length; i++) {
 	    newline = prepareText(lines[i]);

--- a/mathics_django/web/media/js/mathics.js
+++ b/mathics_django/web/media/js/mathics.js
@@ -56,7 +56,7 @@ function isEmpty(textarea) {
 }
 
 function prepareText(text) {
-    return text || String.fromCharCode(160); // non breaking space, like &nbsp;
+    return text.replaceAll(" ", "&nbsp;");
 }
 
 function getDimensions(math, callback) {
@@ -97,7 +97,6 @@ function translateDOMElement(element, svg) {
     if (element.nodeType === 3) {
         return document.createTextNode(element.nodeValue);
     }
-
     const nodeName = element.nodeName;
 
     let dom = null;
@@ -261,7 +260,6 @@ function translateDOMElement(element, svg) {
 function createLine(value) {
     const container = document.createElement('div');
     container.innerHTML = value;
-
     if (container?.firstElementChild?.tagName === 'math') {
         return translateDOMElement(container.firstChild);
     } else if (container?.firstElementChild?.tagName === 'GRAPHICS3D') {
@@ -287,18 +285,17 @@ function createLine(value) {
         return container;
     } else {
         const lines = container.innerText.split('\n');
-
         const p = document.createElement('p');
         p.className = 'string';
 
         for (let i = 0; i < lines.length; i++) {
-            p.innerText += prepareText(lines[i]);
+	    newline = prepareText(lines[i]);
+            p.innerHTML += newline;
 
             if (i < lines.length - 1) {
                 p.appendChild(document.createElement('br'));
             }
         }
-
         return p;
     }
 }
@@ -477,7 +474,7 @@ function setResult(list, results) {
                     li.innerText += out.prefix + ': ';
                 }
 
-                li.appendChild(createLine(out.text));
+                li.appendChild(createLine(out.text.slice(1,-1)));
 
                 resultList.appendChild(li);
             });


### PR DESCRIPTION
Looking at the output of strings produced with the 2d_print mathics-core branch, I realize that multiline strings were not properly shown. This PR fixes this.

Also, this PR removes the quotes in the text shown by `Print`
 