### PR TITLE
is_private seems to have disappeared.

### DIFF
--- a/mathics_django/doc/django_doc.py
+++ b/mathics_django/doc/django_doc.py
@@ -180,7 +180,7 @@ class DjangoDoc(DocumentationEntry):
         return tests
 
     def html(self):
-        items = [item for item in self.items if not item.is_private()]
+        items = [item for item in self.items]
         title_line = self.title + "\n"
         if len(items) and items[0].text.startswith(title_line):
             # In module-style docstring tagging, the first line of the docstring is the section title.
@@ -188,7 +188,7 @@ class DjangoDoc(DocumentationEntry):
             # Or that is the intent. This code is a bit hacky.
             items[0].text = items[0].text[len(title_line) :]
 
-        text = "\n".join(item.html() for item in items if not item.is_private())
+        text = "\n".join(item.html() for item in items)
         if text == "":
             # HACK ALERT if text is "" we may have missed some test markup.
             return mark_safe(escape_html(self.rawdoc))


### PR DESCRIPTION
I am seeing when trying to get the documentation for `TraceBuiltins`

```
...
  File "/tmp/Mathics3/mathics-django/mathics_django/doc/django_doc.py", line 183, in html
    items = [item for item in self.items if not item.is_private()]
                                                ^^^^^^^^^^^^^^^
AttributeError: 'DjangoDocText' object has no attribute 'is_private'

```

`is_private` no longer is part of a DocumentationEntry. 

See https://github.com/Mathics3/mathics-core/blob/master/mathics/doc/doc_entries.py#L431
