### PR TITLE
Add summary information in search

### DIFF
--- a/mathics_django/web/templates/doc/search.html
+++ b/mathics_django/web/templates/doc/search.html
@@ -8,7 +8,8 @@
         {% if item.summary_text %}
           <li>{{ item|link:ajax }} &mdash; <i>{{item.summary_text}}</i></li>
         {% else %}
-          <li>{{ item|link:ajax }}</li>
+          <!-- If an item does not have a summary, it is a section title. So bold it.-->
+          <li><b>{{ item|link:ajax }}</b></li>
 	{% endif %}
       {% endfor %}
     </ul>

--- a/mathics_django/web/templates/doc/search.html
+++ b/mathics_django/web/templates/doc/search.html
@@ -2,13 +2,17 @@
 {% load doc %}
 
 {% block content %}
-	{% if result %}
-		<ul>
-			{% for item in result %}
-				<li>{{ item|link:ajax }}</li>
-			{% endfor %}
-		</ul>
-	{% else %}
-		<p>No items found.</p>
+  {% if result %}
+    <ul>
+      {% for item in result %}
+        {% if item.summary_text %}
+          <li>{{ item|link:ajax }} &mdash; <i>{{item.summary_text}}</i></li>
+        {% else %}
+          <li>{{ item|link:ajax }}</li>
 	{% endif %}
+      {% endfor %}
+    </ul>
+  {% else %}
+     <p>No items found.</p>
+  {% endif %}
 {% endblock content %}


### PR DESCRIPTION
Show summary information in search. For example: 

![image](https://github.com/user-attachments/assets/21b9e597-891d-477b-bb1b-857b8b225d3e)

(Various summaries will soon be corrected in mathics-core to start with active-verb form summary)