### PR TITLE
Adding bottom navigation bar in documentation

### DIFF
--- a/mathics_django/web/templates/doc/base_help.html
+++ b/mathics_django/web/templates/doc/base_help.html
@@ -21,5 +21,23 @@
 
 		{% block content %}
 		{% endblock %}
+		{% if prev or next %}
+		<div style="width:100%;height:10px;border:1px;margin:10px;">
+		</div>
+		<div style="margin-top:20px;  display: flex; justify-content: space-around">
+		{% endif %}
+		{% if prev %}
+		<div>
+		  <span >&larr;</span> {{ prev|link:ajax }}
+		</div>
+		{% endif %}
+		{% if next %}
+		<div>
+		  <span >&rarr;</span> {{ next|link:ajax }}
+		</div>
+		{% endif %}
+		{% if prev or next %}
+		</div>
+		{% endif %}
 	</div>
 {% endblock %}


### PR DESCRIPTION
This PR adds a basic navigation bar at the end of each documentation entry, to avoid the need of going to the top of the page to read the next entry.