### PR TITLE
Support changing the baseURL for ProxySupport

### DIFF
--- a/mathics_django/settings.py
+++ b/mathics_django/settings.py
@@ -37,6 +37,9 @@ else:
     # Use Django's default value for ALLOWED_HOSTS.
     ALLOWED_HOSTS = []
 
+# Support changing the Base URL
+BASE_URL = os.environ.get("MATHICS_DJANGO_URL", None)
+
 DISPLAY_EXCEPTIONS = get_bool_from_environment(
     "MATHICS_DJANGO_DISPLAY_EXCEPTIONS", DEBUG
 )
@@ -159,8 +162,8 @@ SITE_ID = 1
 # Absolute path to the directory that holds static files.
 STATIC_ROOT = os.path.join(ROOT_DIR, "web/media/")
 
-# URL that handles the media served from STATIC_ROOT.
-STATIC_URL = "/media/"
+# URL that handles the media served from STATIC_ROOT (Support BASE_URL change).
+STATIC_URL = BASE_URL+"/media/"
 
 TEMPLATES = [
     {

--- a/mathics_django/settings.py
+++ b/mathics_django/settings.py
@@ -38,7 +38,7 @@ else:
     ALLOWED_HOSTS = []
 
 # Support changing the Base URL
-BASE_URL = os.environ.get("MATHICS_DJANGO_URL", None)
+BASE_URL = os.environ.get("MATHICS_DJANGO_URL", "")
 
 DISPLAY_EXCEPTIONS = get_bool_from_environment(
     "MATHICS_DJANGO_DISPLAY_EXCEPTIONS", DEBUG

--- a/mathics_django/settings.py
+++ b/mathics_django/settings.py
@@ -163,7 +163,7 @@ SITE_ID = 1
 STATIC_ROOT = os.path.join(ROOT_DIR, "web/media/")
 
 # URL that handles the media served from STATIC_ROOT (Support BASE_URL change).
-STATIC_URL = BASE_URL+"/media/"
+STATIC_URL = BASE_URL + "/media/"
 
 TEMPLATES = [
     {

--- a/mathics_django/urls.py
+++ b/mathics_django/urls.py
@@ -12,4 +12,5 @@ urlpatterns = [
     # url(''),
     re_path(r"^", include("mathics_django.web.urls")),
     re_path(r"^"+settings.BASE_URL, include("mathics_django.web.urls")),
+    re_path(r"^"+settings.BASE_URL+"/", include("mathics_django.web.urls")),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/mathics_django/urls.py
+++ b/mathics_django/urls.py
@@ -11,4 +11,5 @@ handler500 = "mathics_django.web.views.error_500_view"
 urlpatterns = [
     # url(''),
     re_path(r"^", include("mathics_django.web.urls")),
+    re_path(r"^"+settings.BASE_URL, include("mathics_django.web.urls")),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/mathics_django/urls.py
+++ b/mathics_django/urls.py
@@ -11,6 +11,6 @@ handler500 = "mathics_django.web.views.error_500_view"
 urlpatterns = [
     # url(''),
     re_path(r"^", include("mathics_django.web.urls")),
-    re_path(r"^"+settings.BASE_URL, include("mathics_django.web.urls")),
-    re_path(r"^"+settings.BASE_URL+"/", include("mathics_django.web.urls")),
+    re_path(r"^" + settings.BASE_URL, include("mathics_django.web.urls")),
+    re_path(r"^" + settings.BASE_URL + "/", include("mathics_django.web.urls")),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/mathics_django/web/media/js/inout.js
+++ b/mathics_django/web/media/js/inout.js
@@ -7,7 +7,7 @@ function showSave() {
 function openWorksheet(name) {
     hidePopup();
 
-    new Ajax.Request('/ajax/open/', {
+    new Ajax.Request('ajax/open/', {
         method: 'post',
         parameters: { name },
         onSuccess: (transport) => {
@@ -23,7 +23,7 @@ function openWorksheet(name) {
 }
 
 function showWorksheets() {
-    new Ajax.Request('/ajax/getworksheets/', {
+    new Ajax.Request('ajax/getworksheets/', {
         method: 'get',
         onSuccess: (transport) => {
             const response = JSON.parse(transport.responseText);
@@ -64,7 +64,7 @@ function showWorksheets() {
 function deleteWorksheet(element, name) {
     element.remove();
 
-    new Ajax.Request('/ajax/delete/', {
+    new Ajax.Request('ajax/delete/', {
         method: 'post',
         parameters: { name }
     });
@@ -96,7 +96,7 @@ function save(overwrite) {
 
     submitForm(
         'saveForm',
-        '/ajax/save/',
+        'ajax/save/',
         (response) => {
             if (!checkLogin(response)) {
                 return;

--- a/mathics_django/web/media/js/mathics.js
+++ b/mathics_django/web/media/js/mathics.js
@@ -521,7 +521,7 @@ function submitQuery(element, onfinish, query) {
     element.li?.classList.add('loading');
     document.getElementById('logo')?.classList.add('working');
 
-    new Ajax.Request('/ajax/query/', {
+    new Ajax.Request('ajax/query/', {
         method: 'post',
         parameters: { query: query || element.value },
         onSuccess: (transport) => {

--- a/mathics_django/web/templates/base.html
+++ b/mathics_django/web/templates/base.html
@@ -22,7 +22,7 @@
 				<a href="javascript:createLink()" title="Generate Worksheet Input Hash"><i class="fa fa-share-alt"></i></a>
 				<a href="javascript:showGallery()" title="Run some demo examples"><i class="fa fa-table"></i></a>
 				<a href="https://github.com/Mathics3" title="Go to Mathics3 GitHub repository"><i class="fa fa-github"></i></a>
-				<a href="/about" title="Mathics3 information page"><i class="fa fa-info"></i></a>
+				<a href="about" title="Mathics3 information page"><i class="fa fa-info"></i></a>
 			</div>
 		</div>
 


### PR DESCRIPTION
See issue - https://github.com/Mathics3/mathics-django/issues/228

This (probably terrible) change will allow you to use the env variable "MATHICS_DJANGO_URL" to support serving the files from a different BASE_URL.

This meant we could serve the application via a proxy, we were using "Open OnDemand" with a proxy configuration we couldn't change and also dynamic proxy addresses.