### PR TITLE
Disable doctest info for Mathics3-Module-trepan...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PYTHON ?= python
 PIP ?= pip3
 RM  ?= rm
 
-MATHICS3_MODULE_OPTION ?= --load-module pymathics.graph,pymathics.natlang,pymathics.trepan
+MATHICS3_MODULE_OPTION ?= --load-module pymathics.graph,pymathics.natlang
 
 .PHONY: all build \
 	check clean \


### PR DESCRIPTION
Disable doctest info for Mathics3-Module-trepan. If it is installed, it will go into the debugger and halt testing.

This is somewhat temporary until better solutions exist. But we shouldn't allow the possibility of making a test go into a debugger.