### PR TITLE
Add Settings`RenderTeXForm

### DIFF
--- a/mathics_django/autoload/settings.m
+++ b/mathics_django/autoload/settings.m
@@ -10,3 +10,6 @@ System`$Notebooks = False;
 
 Settings`$QuotedStrings::usage = "If this Boolean variable is set False, hide the quotes when the top-level value is a string.";
 Settings`$QuotedStrings = True;
+
+Settings`$RenderTeXForm::usage = "If this Boolean variable is set True, TeXForm output is rendered via MathJax.";
+Settings`$RenderTeXForm = True

--- a/mathics_django/web/format.py
+++ b/mathics_django/web/format.py
@@ -105,7 +105,11 @@ def format_output(evaluation, expr, html_tag_format=None):
             # We should probably address a long-standing mistake where strings
             # have quotes in them.
             box_str_sans_quotes = boxed.elements[0].value[1:-1]
-            return f"$${box_str_sans_quotes}$$"
+            render_TeXForm_expr = evaluation.parse("Settings`$RenderTeXForm")
+            render_TeXForm = render_TeXForm_expr.evaluate(evaluation).to_python()
+            if render_TeXForm:
+                box_str_sans_quotes = f"$${box_str_sans_quotes}$$"
+            return box_str_sans_quotes
 
         # THINK ABOUT: This probably no longer happens
         if isinstance(boxed, String):


### PR DESCRIPTION
If True (the default) TeXForm output is rendered using MathJax. Otherwise it appears as LaTeX output.